### PR TITLE
[2.1] - API health, diagnostics, and environment visibility

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -1,133 +1,148 @@
-require("dotenv").config();
-var createError = require("http-errors");
-var cors = require("cors");
-var express = require("express");
-var path = require("path");
-var cookieParser = require("cookie-parser");
-var logger = require("morgan");
+require('dotenv').config();
+var createError = require('http-errors');
+var cors = require('cors');
+var express = require('express');
+var path = require('path');
+var cookieParser = require('cookie-parser');
+var logger = require('morgan');
 
-var indexRouter = require("./routes/index");
-var standingsRouter = require("./routes/standings");
-var playerRouter = require("./routes/player");
-var teamRouter = require("./routes/team");
-const { router: scheduleRouter, refreshScheduleCache } = require("./routes/schedule");
+var indexRouter = require('./routes/index');
+var healthRouter = require('./routes/health');
+var standingsRouter = require('./routes/standings');
+var playerRouter = require('./routes/player');
+var teamRouter = require('./routes/team');
+const {
+	router: scheduleRouter,
+	refreshScheduleCache,
+} = require('./routes/schedule');
 
-const { spawn } = require("child_process");
-const { readCache, writeCache, CACHE_TYPES } = require("./utils/cacheManager");
+const { spawn } = require('child_process');
+const { readCache, writeCache, CACHE_TYPES } = require('./utils/cacheManager');
 
 let corsOptions = {
-  origin: ["http://localhost:3000", "http://localhost:5173", "https://chrisgawbill.github.io"],
+	origin: [
+		'http://localhost:3000',
+		'http://localhost:5173',
+		'https://chrisgawbill.github.io',
+	],
+	allowedHeaders: ['Content-Type', 'x-diagnostics-key'],
 };
 
 var app = express();
 
 // view engine setup
-app.set("views", path.join(__dirname, "views"));
-app.set("view engine", "jade");
+app.set('views', path.join(__dirname, 'views'));
+app.set('view engine', 'jade');
 
 app.use(cors(corsOptions));
-app.use(logger("dev"));
+app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, "public")));
+app.use(express.static(path.join(__dirname, 'public')));
 
-app.use("/", indexRouter);
-app.use("/standings", standingsRouter);
-app.use("/player", playerRouter);
-app.use("/team", teamRouter);
-app.use("/schedule", scheduleRouter);
+app.use('/', indexRouter);
+app.use('/health', healthRouter);
+app.use('/standings', standingsRouter);
+app.use('/player', playerRouter);
+app.use('/team', teamRouter);
+app.use('/schedule', scheduleRouter);
 
-app.post("/python-service", async (req, res, next) => {
-  try {
-    const message = req.body.content;
-    const key = req.body.cacheKey ?? "default";
+app.post('/python-service', async (req, res, next) => {
+	try {
+		const message = req.body.content;
+		const key = req.body.cacheKey ?? 'default';
 
-    const cached = await readCache(CACHE_TYPES.AI, key);
-    if (cached !== null) {
-      return res.send(cached);
-    }
+		const cached = await readCache(CACHE_TYPES.AI, key);
+		if (cached !== null) {
+			return res.send(cached);
+		}
 
-    const result = await runAIPythonScript(message);
-    await writeCache(CACHE_TYPES.AI, key, result);
-    res.send(result);
-  } catch (error) {
-    next(error);
-  }
+		const result = await runAIPythonScript(message);
+		await writeCache(CACHE_TYPES.AI, key, result);
+		res.send(result);
+	} catch (error) {
+		next(error);
+	}
 });
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {
-  next(createError(404));
+	next(createError(404));
 });
 
 // error handler
 app.use(function (err, req, res, next) {
-  console.error(`${req.method} ${req.originalUrl} failed:`, err);
-  res.status(err.status || 500).json({ error: err.message ?? "Internal server error" });
+	console.error(`${req.method} ${req.originalUrl} failed:`, err);
+	res
+		.status(err.status || 500)
+		.json({ error: err.message ?? 'Internal server error' });
 });
 
-const runAIPythonScript = (message) =>{
-  return new Promise((resolve, reject) => {
-    const pythonPath = process.env.NODE_ENV === "production" ? "python3" : path.join(__dirname, "venv/bin/python3");
-    const pythonProcess = spawn(
-      pythonPath,
-      [path.join(__dirname, "routes/hockey-ai.py"), message]
-    );
+const runAIPythonScript = (message) => {
+	return new Promise((resolve, reject) => {
+		const pythonPath =
+			process.env.NODE_ENV === 'production' ?
+				'python3'
+			:	path.join(__dirname, 'venv/bin/python3');
+		const pythonProcess = spawn(pythonPath, [
+			path.join(__dirname, 'routes/hockey-ai.py'),
+			message,
+		]);
 
-    let stdoutData = "";
+		let stdoutData = '';
 
-    pythonProcess.on("error", (err) => {
-      console.error("Failed to start python process: ", err);
-      reject(`Failed to start python process: ${err.message}`);
-    });
-    pythonProcess.stdout.on("data", (data) => {
-      stdoutData += data.toString();
-    });
-    pythonProcess.stderr.on("data", (data) => {
-      console.error("stderr: " + data);
-    });
-    pythonProcess.on("close", (code) => {
-      console.log("child process exited with code: " + code);
-      if (code !== 0) {
-        reject(`Process exited with code ${code}`);
-      } else {
-        try {
-          const jsonReponse = JSON.parse(stdoutData);
-          if (jsonReponse.error) {
-            reject(jsonReponse.error);
-          } else {
-            resolve(jsonReponse.data);
-          }
-        } catch (e) {
-          reject(`Error parsing JSON response\n${stdoutData}`);
-        }
-      }
-    });
-  });
-}
+		pythonProcess.on('error', (err) => {
+			console.error('Failed to start python process: ', err);
+			reject(`Failed to start python process: ${err.message}`);
+		});
+		pythonProcess.stdout.on('data', (data) => {
+			stdoutData += data.toString();
+		});
+		pythonProcess.stderr.on('data', (data) => {
+			console.error('stderr: ' + data);
+		});
+		pythonProcess.on('close', (code) => {
+			console.log('child process exited with code: ' + code);
+			if (code !== 0) {
+				reject(`Process exited with code ${code}`);
+			} else {
+				try {
+					const jsonReponse = JSON.parse(stdoutData);
+					if (jsonReponse.error) {
+						reject(jsonReponse.error);
+					} else {
+						resolve(jsonReponse.data);
+					}
+				} catch (e) {
+					reject(`Error parsing JSON response\n${stdoutData}`);
+				}
+			}
+		});
+	});
+};
 // Schedule cache refreshes at 8AM, 7PM, 11PM UTC
 const REFRESH_HOURS_UTC = [8, 19, 23];
 function scheduleNextRefresh() {
-  const now = new Date();
-  let nextMs = null;
-  for (const hour of REFRESH_HOURS_UTC) {
-    const candidate = new Date(now);
-    candidate.setUTCHours(hour, 0, 0, 0);
-    if (candidate.getTime() > now.getTime()) {
-      nextMs = candidate.getTime();
-      break;
-    }
-  }
-  if (!nextMs) {
-    const tomorrow = new Date(now);
-    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-    tomorrow.setUTCHours(REFRESH_HOURS_UTC[0], 0, 0, 0);
-    nextMs = tomorrow.getTime();
-  }
-  setTimeout(async () => {
-    await refreshScheduleCache();
-    scheduleNextRefresh();
-  }, nextMs - now.getTime());
+	const now = new Date();
+	let nextMs = null;
+	for (const hour of REFRESH_HOURS_UTC) {
+		const candidate = new Date(now);
+		candidate.setUTCHours(hour, 0, 0, 0);
+		if (candidate.getTime() > now.getTime()) {
+			nextMs = candidate.getTime();
+			break;
+		}
+	}
+	if (!nextMs) {
+		const tomorrow = new Date(now);
+		tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+		tomorrow.setUTCHours(REFRESH_HOURS_UTC[0], 0, 0, 0);
+		nextMs = tomorrow.getTime();
+	}
+	setTimeout(async () => {
+		await refreshScheduleCache();
+		scheduleNextRefresh();
+	}, nextMs - now.getTime());
 }
 scheduleNextRefresh();
 

--- a/api/routes/health.js
+++ b/api/routes/health.js
@@ -1,0 +1,34 @@
+var express = require('express');
+var cacheManager = require('../utils/cacheManager');
+const { authCheck } = require('../utils/auth');
+
+var router = express.Router();
+router.use(authCheck);
+
+router.get('/', async function (req, res, next) {
+	try {
+		res.json({
+			status: 'ok',
+			version: require('../package.json').version,
+			environment: process.env.NODE_ENV || 'development',
+			currentSeason: require('../utils/seasonHelper').getCurrentSeasonId(),
+			cacheWritable: await cacheManager.isCacheWritable(),
+			anthropicKeyConfigured: Boolean(process.env.ANTHROPIC_API_KEY),
+			uptime: process.uptime(),
+			currentTime: new Date().toISOString(),
+		});
+	} catch (e) {
+		next(e);
+	}
+});
+
+router.get('/cache-usage', async function (req, res, next) {
+	try {
+		const usage = await cacheManager.getCacheUsage();
+		res.json(usage);
+	} catch (e) {
+		next(e);
+	}
+});
+
+module.exports = router;

--- a/api/utils/auth.js
+++ b/api/utils/auth.js
@@ -1,0 +1,21 @@
+const crypto = require('crypto');
+
+function matchesPassphrase(providedPassphrase) {
+	const expectedPassphrase = process.env.DIAGNOSTICS_PASSPHRASE;
+	if (!expectedPassphrase || !providedPassphrase) {
+		return false;
+	}
+	const a = crypto.createHash('sha256').update(providedPassphrase).digest();
+	const b = crypto.createHash('sha256').update(expectedPassphrase).digest();
+	return crypto.timingSafeEqual(a, b);
+}
+
+function authCheck(req, res, next) {
+	const passphrase = req.get('x-diagnostics-key');
+	if (!matchesPassphrase(passphrase)) {
+		return res.status(401).json({ error: 'Unauthorized' });
+	}
+    next();
+}
+
+module.exports = { authCheck };

--- a/api/utils/cacheManager.js
+++ b/api/utils/cacheManager.js
@@ -1,72 +1,134 @@
-var fs = require("fs");
-var path = require("path");
+var fs = require('fs');
+var path = require('path');
 
 const inFlight = new Map();
 
 const CACHE_TYPES = {
-  PLAYER:      'player',
-  ROSTER:      'roster',
-  AI:          'ai',
-  SCHEDULE:    'schedule',
-  STANDINGS:   'standings',
-  STAT_LEADERS:'stat-leaders',
+	PLAYER: 'player',
+	ROSTER: 'roster',
+	AI: 'ai',
+	SCHEDULE: 'schedule',
+	STANDINGS: 'standings',
+	STAT_LEADERS: 'stat-leaders',
 };
 
 const CACHE_DIRS = {
-  [CACHE_TYPES.PLAYER]:       path.join(__dirname, "../player-cache/"),
-  [CACHE_TYPES.ROSTER]:       path.join(__dirname, "../roster-cache/"),
-  [CACHE_TYPES.AI]:           path.join(__dirname, "../ai-cache/"),
-  [CACHE_TYPES.SCHEDULE]:     path.join(__dirname, "../schedule-cache/"),
-  [CACHE_TYPES.STANDINGS]:    path.join(__dirname, "../standings-cache/"),
-  [CACHE_TYPES.STAT_LEADERS]: path.join(__dirname, "../stat-leaders-cache/"),
+	[CACHE_TYPES.PLAYER]: path.join(__dirname, '../player-cache/'),
+	[CACHE_TYPES.ROSTER]: path.join(__dirname, '../roster-cache/'),
+	[CACHE_TYPES.AI]: path.join(__dirname, '../ai-cache/'),
+	[CACHE_TYPES.SCHEDULE]: path.join(__dirname, '../schedule-cache/'),
+	[CACHE_TYPES.STANDINGS]: path.join(__dirname, '../standings-cache/'),
+	[CACHE_TYPES.STAT_LEADERS]: path.join(__dirname, '../stat-leaders-cache/'),
 };
 
 const CACHE_TTLS = {
-  [CACHE_TYPES.PLAYER]:       24  * 60 * 60 * 1000,
-  [CACHE_TYPES.ROSTER]:       24  * 60 * 60 * 1000,
-  [CACHE_TYPES.AI]:           365 * 24 * 60 * 60 * 1000,
-  [CACHE_TYPES.SCHEDULE]:     12  * 60 * 60 * 1000,
-  [CACHE_TYPES.STANDINGS]:    24  * 60 * 60 * 1000,
-  [CACHE_TYPES.STAT_LEADERS]: 24  * 60 * 60 * 1000,
+	[CACHE_TYPES.PLAYER]: 24 * 60 * 60 * 1000,
+	[CACHE_TYPES.ROSTER]: 24 * 60 * 60 * 1000,
+	[CACHE_TYPES.AI]: 365 * 24 * 60 * 60 * 1000,
+	[CACHE_TYPES.SCHEDULE]: 12 * 60 * 60 * 1000,
+	[CACHE_TYPES.STANDINGS]: 24 * 60 * 60 * 1000,
+	[CACHE_TYPES.STAT_LEADERS]: 24 * 60 * 60 * 1000,
 };
 
 async function readCache(type, key) {
-  const filePath = path.join(CACHE_DIRS[type], `${key}.json`);
-  try {
-    const entry = JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
-    if (Date.now() - entry.timestamp < CACHE_TTLS[type]){
-      return entry.data;
-    } 
-  } catch {}
-  return null;
+	const filePath = path.join(CACHE_DIRS[type], `${key}.json`);
+	try {
+		const entry = JSON.parse(await fs.promises.readFile(filePath, 'utf-8'));
+		if (Date.now() - entry.timestamp < CACHE_TTLS[type]) {
+			return entry.data;
+		}
+	} catch {}
+	return null;
 }
 
 async function writeCache(type, key, data) {
-  const filePath = path.join(CACHE_DIRS[type], `${key}.json`);
-  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.promises.writeFile(filePath, JSON.stringify({ timestamp: Date.now(), data }));
+	const filePath = path.join(CACHE_DIRS[type], `${key}.json`);
+	await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.promises.writeFile(
+		filePath,
+		JSON.stringify({ timestamp: Date.now(), data }),
+	);
 }
 
-async function GetOrFetch(type, key, fetcher){
-  const cached = await readCache(type, key);
-  if(cached !== null){
-    return cached;
+async function GetOrFetch(type, key, fetcher) {
+	const cached = await readCache(type, key);
+	if (cached !== null) {
+		return cached;
+	}
+	const inFlightKey = `${type}:${key}`;
+	if (inFlight.has(inFlightKey)) {
+		return await inFlight.get(inFlightKey);
+	}
+	const promise = fetcher()
+		.then(async (data) => {
+			try {
+				await writeCache(type, key, data);
+			} catch (error) {
+				console.error(`Failed to write ${type} cache for ${key}:`, error);
+			}
+			return data;
+		})
+		.finally(() => inFlight.delete(inFlightKey));
+
+	inFlight.set(inFlightKey, promise);
+	return await promise;
+}
+
+async function isCacheWritable() {
+	try {
+		await fs.promises.access(path.join(__dirname, '../'), fs.constants.W_OK);
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
+
+async function getCacheUsage() {
+  let cacheUsage = {
+    sections : {},
+    largestSection: null,
+    total: 0,
   }
-  const inFlightKey = `${type}:${key}`;
-  if(inFlight.has(inFlightKey)){
-    return await inFlight.get(inFlightKey);
-  }
-  const promise = fetcher().then(async data => {
-    try {
-      await writeCache(type, key, data);
-    } catch (error) {
-      console.error(`Failed to write ${type} cache for ${key}:`, error);
+	for (const [type, dir] of Object.entries(CACHE_DIRS)) {
+		cacheUsage.sections[type] = await dirSize(dir);
+		cacheUsage.total += cacheUsage.sections[type];
+	}
+  cacheUsage.largestSection = Object.entries(cacheUsage.sections).reduce((largest, [type, size]) => {
+    if (size > largest.size) {
+      return { type, size };
     }
-    return data;
-  }).finally(() => inFlight.delete(inFlightKey));
-
-  inFlight.set(inFlightKey, promise);
-  return await promise;
+    return largest;
+  }, { type: null, size: 0 });
+	return cacheUsage;
 }
 
-module.exports = { readCache, writeCache, CACHE_TYPES, GetOrFetch };
+async function dirSize(dir) {
+	let total = 0;
+	let files;
+	try {
+		files = await fs.promises.readdir(dir);
+	} catch (e) {
+		return 0;
+	}
+
+	for (const file of files) {
+		try {
+			const stat = await fs.promises.stat(path.join(dir, file));
+			if (stat.isFile()) {
+				total += stat.size;
+			}
+		} catch (e) {
+			continue;
+		}
+	}
+	return total;
+}
+
+module.exports = {
+	readCache,
+	writeCache,
+	CACHE_TYPES,
+	GetOrFetch,
+	isCacheWritable,
+	getCacheUsage,
+};

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ React pages/components
 │   ├── src/index.tsx       React root and global context providers
 │   ├── src/Pages/          Route-level page components
 │   ├── src/Components/     Reusable UI sections and widgets
-│   ├── src/Data/           Models, contexts, helpers, constants, and local data
+│   ├── src/Data/           Models, contexts, hooks, helpers, constants, and local data
 │   ├── src/Services/       Frontend API clients and service functions
 │   └── src/style/          CSS modules, shared CSS, and image assets
 └── docs/architecture.md    This file
@@ -48,6 +48,7 @@ The frontend is a Vite React app using TypeScript, React Router, React Bootstrap
 - `/teamList` renders `TeamList`
 - `/team/:teamId` renders `TeamPage`
 - `/game/:gameId` renders `GameDetailPage`
+- `/diagnostics` renders `DiagnosticsPage` (intentionally unlinked; see [Diagnostics Layer](#diagnostics-layer))
 
 Because this uses `HashRouter`, URLs are intended to work in static hosting environments such as GitHub Pages.
 
@@ -81,6 +82,9 @@ Frontend HTTP calls are centralized in:
 - `GetGameDetails(gameID)` calls `/schedule/:gameID`
 - `GetTeamRoster(triCode)` calls `/team/roster/:triCode`
 - `GetSkaterSummary(teamId)` calls `/player/skater/summary`
+- `GetHealth(passphrase)` calls `/health` and `GetCacheReport(passphrase)` calls `/health/cache-usage`; both attach the passphrase as the `x-diagnostics-key` header (never a query string), since the backend reads it from that header (see [Diagnostics Layer](#diagnostics-layer))
+
+Note: `ApiHandler.ts` also exports `GetDraft()`, but it is currently an empty stub (its body is commented out). Draft lottery odds are not fetched from an API; they are computed locally (see [Important Hockey And NHL API Background](#important-hockey-and-nhl-api-background)).
 
 `GenAIHandler.ts` calls `/python-service` and normalizes the AI response into JSON when possible.
 
@@ -93,6 +97,7 @@ Use this structure when deciding where code belongs:
 - `Models/`: class-like data shapes used by the UI, such as `ScheduledGame`, `Team`, `StandingsTeam`, and `PlayerStatLeader`.
 - `Helpers/`: conversion logic from raw NHL API responses into app models.
 - `Context/`: React providers and hooks for shared state.
+- `Hooks/`: reusable custom hooks that compose services, helpers, and constants. For example, `useStatLeaders.ts` loads and tracks stat leader data using `STAT_CONFIG` and `PlayerStatLeaderConverter`.
 - `Constants/`: static configuration such as stat leader category mappings.
 - `LocalData/`: local static NHL team metadata and mock-shaped page data.
 
@@ -155,10 +160,20 @@ Routes are grouped by NHL domain:
   - `GET /player/goalie/summary`
   - Uses NHL skater and goalie stats endpoints
 
+- `api/routes/health.js`
+  - `GET /health`
+  - `GET /health/cache-usage`
+  - Passphrase-protected diagnostics endpoints (see [Diagnostics Layer](#diagnostics-layer))
+
 - `POST /python-service`
   - Defined in `api/app.js`
   - Calls `api/routes/hockey-ai.py` through a Python subprocess
   - Caches AI responses by cache key
+
+- `api/routes/index.js`
+  - `GET /`, mounted in `api/app.js` as `indexRouter`
+  - Leftover Express-generator scaffolding: it calls `res.render('index', ...)`, which expects a view engine/template this API does not configure
+  - It serves no real purpose for this app and can likely be removed; do not build on it
 
 ### NHL API Clients
 
@@ -224,6 +239,36 @@ Important details:
 - In production, Express uses `python3`.
 - AI responses are cached for a long time using `CACHE_TYPES.AI`.
 - AI output should be treated as helpful but not authoritative unless separately verified.
+
+## Diagnostics Layer
+
+The app exposes a small, passphrase-protected diagnostics layer for inspecting backend health and cache usage.
+
+End-to-end flow:
+
+```text
+DiagnosticsPage (unlinked route #/diagnostics)
+  -> GetHealth(passphrase) / GetCacheReport(passphrase)  (x-diagnostics-key header)
+  -> api/routes/health.js  (authCheck middleware)
+  -> seasonHelper, cacheManager, process env
+```
+
+### Endpoints
+
+- `GET /health` returns API status, app version, environment, current `seasonId`, cache-directory writability, whether `ANTHROPIC_API_KEY` is configured, uptime, and server time. Sensitive values are reported as booleans/status only, never as raw values.
+- `GET /health/cache-usage` returns per-section cache sizes in bytes, the largest section, and the total.
+
+### Authentication model
+
+The single most important rule: **the backend is the only real gate.** Because the frontend is a static SPA, any check done in React is bypassable, and the Express endpoints are publicly reachable. So:
+
+- `api/utils/auth.js` holds `matchesPassphrase` (a pure, constant-time `crypto.timingSafeEqual` comparison against `DIAGNOSTICS_PASSPHRASE`, failing closed if unset) and `authCheck`, an Express middleware applied via `router.use(authCheck)` in `health.js`. It guards every route in that module and returns `401` without the correct passphrase.
+- The passphrase travels in the `x-diagnostics-key` **header**, not a query string, so it is not written to request logs or browser history. `app.js` lists this header in CORS `allowedHeaders` so the browser preflight succeeds.
+- `DIAGNOSTICS_PASSPHRASE` lives only in `api/.env` and is generated with high entropy (e.g. `crypto.randomBytes(32)`); it must never be committed or baked into the frontend bundle.
+
+### Frontend
+
+`DiagnosticsPage` is an unlinked route — "hidden" only by obscurity, which is acceptable because the backend enforces access. It shows a passphrase gate, then renders an MD3 status grid and a cache-usage table (bytes formatted for display on the frontend). The entered passphrase is kept in `sessionStorage` so a refresh stays authenticated within the tab; a wrong passphrase or unreachable API is caught and surfaced without crashing the app.
 
 ## Important Hockey And NHL API Background
 

--- a/docs/phase-2-backlog.md
+++ b/docs/phase-2-backlog.md
@@ -4,7 +4,7 @@ Future feature roadmap for the HockeyStatsWebApp. Items are ordered so shared ba
 
 ## 2.1 API health, diagnostics, and environment visibility
 
-- [ ] **Owner:** Either | **Depends on:** Architecture baseline
+- [x] **Owner:** Either | **Depends on:** Architecture baseline | **Done:** 2026-05-31 (see [phase-2-progress.md](./phase-2-progress.md#21--api-health-diagnostics-and-environment-visibility))
 
 Add lightweight operational visibility so local development and deployments can quickly answer whether the React app, Express API, NHL upstreams, cache folders, and optional AI integration are configured correctly.
 

--- a/docs/phase-2-progress.md
+++ b/docs/phase-2-progress.md
@@ -1,0 +1,170 @@
+# Phase 2 Progress Log
+
+A working journal for the Phase 2 roadmap (see [phase-2-backlog.md](./phase-2-backlog.md)).
+Each task has two sections to fill in as it gets worked:
+
+- **What I have done** — the concrete changes that shipped (files, endpoints, components).
+- **What I have learned** — the concepts, gotchas, and decisions worth remembering later.
+
+Status legend: ☐ not started · ◐ in progress · ☑ done
+
+---
+
+## ☑ 2.1 — API health, diagnostics, and environment visibility
+
+**Completed:** 2026-05-31
+
+### What I have done
+
+- Added `GET /health` and `GET /health/cache-usage` in a dedicated route module `api/routes/health.js`, mounted at `/health` in `api/app.js`.
+- `/health` returns: `status`, `version` (from `api/package.json`), `environment`, `currentSeason` (from `seasonHelper.getCurrentSeasonId()`), `cacheWritable`, `anthropicKeyConfigured`, `uptime`, and `currentTime`.
+- `/health/cache-usage` reports per-section cache sizes in bytes, the largest section, and the total.
+- Added cache helpers `isCacheWritable()` and `getCacheUsage()` (with a `dirSize()` helper) to `api/utils/cacheManager.js`.
+- Added passphrase auth in `api/utils/auth.js`: `matchesPassphrase` (SHA-256 + `crypto.timingSafeEqual`, fails closed if `DIAGNOSTICS_PASSPHRASE` is unset) and an `authCheck` middleware applied via `router.use(authCheck)`.
+- Allowed the `x-diagnostics-key` header in CORS `allowedHeaders` in `api/app.js` so browser preflight succeeds.
+- Added frontend service functions `GetHealth(passphrase)` and `GetCacheReport(passphrase)` in `react/src/Services/ApiHandler.ts`, passing the passphrase in the `x-diagnostics-key` header.
+- Added an unlinked `DiagnosticsPage` (`react/src/Pages/DiagnosticsPage.tsx`) at the `/diagnostics` route, with a passphrase gate, status grid, and cache-usage table. Styled in `react/src/style/DiagnosticsPage.module.css`.
+- Passphrase is kept in `sessionStorage` so a refresh stays authenticated within the tab; wrong passphrase (401) and unreachable API are caught and surfaced without crashing the app.
+- `DIAGNOSTICS_PASSPHRASE` stored only in `api/.env` (gitignored).
+- Documented the whole layer in `docs/architecture.md` (Diagnostics Layer section).
+
+### What I have learned
+
+- **The backend is the only real gate.** A static SPA ships its source to the browser, and the Express endpoints are publicly reachable, so any "development-only" or hidden check in React is bypassable. Enforcement has to live in server middleware (`authCheck`), not the UI. The unlinked `/diagnostics` route is "hidden" only by obscurity — acceptable *because* the server enforces access.
+- **Pass secrets in a header, not a query string.** Query strings leak into request logs and browser history; the `x-diagnostics-key` header avoids that. Custom headers also require listing in CORS `allowedHeaders` or the browser preflight fails.
+- **Constant-time comparison matters for secrets.** Hashing both sides with SHA-256 first gives equal-length buffers for `timingSafeEqual` and avoids leaking length or short-circuiting early on the first differing byte.
+- **Fail closed.** If `DIAGNOSTICS_PASSPHRASE` is unset, auth returns false rather than allowing access.
+- **Report status, never raw secrets.** The Anthropic key is exposed only as `anthropicKeyConfigured: Boolean(...)`.
+- **Keep formatting churn out of feature diffs.** This change carried a lot of Prettier/tabs reformatting mixed with the real edits, which makes review harder — formatting-only changes belong in a separate commit.
+
+---
+
+## ☐ 2.2 — Normalize API response contracts
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.3 — Season and date range controls
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.4 — Schedule search, filters, and team calendar
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.5 — Enhanced game detail pages
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.6 — Team page depth: roster, schedule, leaders, and history
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.7 — Player profile pages
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.8 — Favorites and personalized dashboard
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.9 — Advanced standings and playoff race views
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.10 — Search across teams, players, and games
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.11 — AI history hardening and source separation
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_
+
+---
+
+## ☐ 2.12 — Test coverage and release readiness
+
+### What I have done
+
+_TODO_
+
+### What I have learned
+
+_TODO_

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -5,6 +5,7 @@ import TeamPage from "./Pages/TeamPage";
 import TeamList from "./Pages/TeamList";
 import SchedulePage from "./Pages/SchedulePage";
 import GameDetailPage from "./Pages/GameDetailPage";
+import DiagnosticsPage from "./Pages/DiagnosticsPage";
 
 export default function App() {
   return (
@@ -16,6 +17,7 @@ export default function App() {
         <Route path="teamList" element={<TeamList/>} />
         <Route path="team/:teamId" element={<TeamPage />} />
         <Route path="game/:gameId" element={<GameDetailPage />} />
+        <Route path="diagnostics" element={<DiagnosticsPage />} />
       </Routes>
     </HashRouter>
   );

--- a/react/src/Pages/DiagnosticsPage.tsx
+++ b/react/src/Pages/DiagnosticsPage.tsx
@@ -1,0 +1,376 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import PageHeader from '../Components/PageHeader';
+import LoadingState from '../Components/LoadingState';
+import { GetHealth, GetCacheReport } from '../Services/ApiHandler';
+import styles from '../style/DiagnosticsPage.module.css';
+
+const cx = (...classes: Array<string | false | null | undefined>) =>
+	classes.filter(Boolean).join(' ');
+
+const SESSION_KEY = 'diagnostics-key';
+
+interface HealthData {
+	status: string;
+	version: string;
+	environment: string;
+	currentSeason: string;
+	cacheWritable: boolean;
+	anthropicKeyConfigured: boolean;
+	uptime: number;
+	currentTime: string;
+}
+
+interface CacheReportData {
+	sections: Record<string, number>;
+	largestSection: { type: string | null; size: number };
+	total: number;
+}
+
+function formatBytes(bytes: number): string {
+	if (!bytes) return '0 B';
+	const units = ['B', 'KB', 'MB', 'GB'];
+	const i = Math.min(
+		Math.floor(Math.log(bytes) / Math.log(1024)),
+		units.length - 1,
+	);
+	const value = bytes / Math.pow(1024, i);
+	return `${i === 0 ? value : value.toFixed(1)} ${units[i]}`;
+}
+
+function formatUptime(seconds: number): string {
+	const s = Math.floor(seconds % 60);
+	const m = Math.floor((seconds / 60) % 60);
+	const h = Math.floor(seconds / 3600);
+	const parts: string[] = [];
+	if (h) parts.push(`${h}h`);
+	if (h || m) parts.push(`${m}m`);
+	parts.push(`${s}s`);
+	return parts.join(' ');
+}
+
+function LockIcon() {
+	return (
+		<svg
+			width='22'
+			height='22'
+			viewBox='0 0 24 24'
+			fill='none'
+			stroke='currentColor'
+			strokeWidth='2'
+			strokeLinecap='round'
+			strokeLinejoin='round'
+			aria-hidden='true'
+		>
+			<rect x='3' y='11' width='18' height='11' rx='2' ry='2' />
+			<path d='M7 11V7a5 5 0 0 1 10 0v4' />
+		</svg>
+	);
+}
+
+function RefreshIcon() {
+	return (
+		<svg
+			width='18'
+			height='18'
+			viewBox='0 0 24 24'
+			fill='none'
+			stroke='currentColor'
+			strokeWidth='2'
+			strokeLinecap='round'
+			strokeLinejoin='round'
+			aria-hidden='true'
+		>
+			<polyline points='23 4 23 10 17 10' />
+			<polyline points='1 20 1 14 7 14' />
+			<path d='M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15' />
+		</svg>
+	);
+}
+
+function StatusBadge({
+	ok,
+	okLabel = 'Available',
+	badLabel = 'Unavailable',
+}: {
+	ok: boolean;
+	okLabel?: string;
+	badLabel?: string;
+}) {
+	return (
+		<span
+			className={cx(
+				styles['status-badge'],
+				ok ? styles['status-badge--ok'] : styles['status-badge--bad'],
+			)}
+		>
+			<span className={styles['status-badge__dot']} aria-hidden='true' />
+			{ok ? okLabel : badLabel}
+		</span>
+	);
+}
+
+function StatCard({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className={styles['diagnostics-stat-card']}>
+			<span className={styles['diagnostics-stat-card__label']}>{label}</span>
+			<span className={styles['diagnostics-stat-card__value']}>{children}</span>
+		</div>
+	);
+}
+
+const DiagnosticsPage = () => {
+	const [passphrase, setPassphrase] = useState('');
+	const [health, setHealth] = useState<HealthData | null>(null);
+	const [cacheReport, setCacheReport] = useState<CacheReportData | null>(null);
+	const [authed, setAuthed] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [authError, setAuthError] = useState(false);
+	const [fetchError, setFetchError] = useState(false);
+
+	const loadDiagnostics = useCallback(async (key: string) => {
+		setLoading(true);
+		setAuthError(false);
+		setFetchError(false);
+		try {
+			const [healthData, cacheData] = await Promise.all([
+				GetHealth(key),
+				GetCacheReport(key),
+			]);
+			setHealth(healthData);
+			setCacheReport(cacheData);
+			setAuthed(true);
+			sessionStorage.setItem(SESSION_KEY, key);
+		} catch (error: any) {
+			sessionStorage.removeItem(SESSION_KEY);
+			setAuthed(false);
+			if (error?.response?.status === 401) {
+				setAuthError(true);
+			} else {
+				setFetchError(true);
+			}
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	// Re-use a passphrase stored earlier this tab session so a refresh keeps you in.
+	useEffect(() => {
+		const stored = sessionStorage.getItem(SESSION_KEY);
+		if (stored) {
+			setPassphrase(stored);
+			loadDiagnostics(stored);
+		}
+	}, [loadDiagnostics]);
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		const key = passphrase.trim();
+		if (!key) return;
+		loadDiagnostics(key);
+	};
+
+	const handleLock = () => {
+		sessionStorage.removeItem(SESSION_KEY);
+		setAuthed(false);
+		setHealth(null);
+		setCacheReport(null);
+		setPassphrase('');
+	};
+
+	const renderGate = () => (
+		<div className={styles['diagnostics-gate-wrap']}>
+			<div className={styles['diagnostics-gate']}>
+				<span className={styles['diagnostics-gate__icon']} aria-hidden='true'>
+					<LockIcon />
+				</span>
+				<h1 className={styles['diagnostics-gate__title']}>Diagnostics</h1>
+				<p className={styles['diagnostics-gate__desc']}>
+					This page is restricted. Enter the diagnostics passphrase to view API
+					status and cache usage.
+				</p>
+				<form
+					className={styles['diagnostics-gate__form']}
+					onSubmit={handleSubmit}
+				>
+					<input
+						className={styles['diagnostics-gate__input']}
+						type='password'
+						value={passphrase}
+						onChange={(e) => setPassphrase(e.target.value)}
+						placeholder='Passphrase'
+						aria-label='Diagnostics passphrase'
+						autoComplete='current-password'
+						autoFocus
+					/>
+					<button
+						className={styles['diagnostics-gate__button']}
+						type='submit'
+						disabled={loading || !passphrase.trim()}
+					>
+						{loading ? 'Checking…' : 'Unlock'}
+					</button>
+					{authError && (
+						<p className={styles['diagnostics-gate__error']}>
+							Incorrect passphrase. Try again.
+						</p>
+					)}
+					{fetchError && (
+						<p className={styles['diagnostics-gate__error']}>
+							Could not reach the API. Is the backend running?
+						</p>
+					)}
+				</form>
+			</div>
+		</div>
+	);
+
+	const renderContent = () => {
+		if (!health || !cacheReport) return null;
+		const sectionRows = Object.entries(cacheReport.sections).sort(
+			(a, b) => b[1] - a[1],
+		);
+		return (
+			<div className={styles['diagnostics-page__content']}>
+				<div className={styles['diagnostics-header']}>
+					<h1 className={styles['diagnostics-title']}>Diagnostics</h1>
+					<div className={styles['diagnostics-actions']}>
+						<button
+							className={styles['diagnostics-icon-btn']}
+							onClick={() => loadDiagnostics(passphrase.trim())}
+							disabled={loading}
+							aria-label='Refresh diagnostics'
+						>
+							<RefreshIcon />
+							<span>Refresh</span>
+						</button>
+						<button
+							className={styles['diagnostics-icon-btn']}
+							onClick={handleLock}
+							aria-label='Lock diagnostics'
+						>
+							<LockIcon />
+							<span>Lock</span>
+						</button>
+					</div>
+				</div>
+
+				<section className={styles['diagnostics-section']}>
+					<h2 className={styles['diagnostics-section__title']}>API Status</h2>
+					<div className={styles['diagnostics-grid']}>
+						<StatCard label='Status'>
+							<StatusBadge
+								ok={health.status === 'ok'}
+								okLabel='OK'
+								badLabel='Down'
+							/>
+						</StatCard>
+						<StatCard label='Cache Directory'>
+							<StatusBadge
+								ok={health.cacheWritable}
+								okLabel='Writable'
+								badLabel='Unavailable'
+							/>
+						</StatCard>
+						<StatCard label='Anthropic Key'>
+							<StatusBadge
+								ok={health.anthropicKeyConfigured}
+								okLabel='Configured'
+								badLabel='Missing'
+							/>
+						</StatCard>
+						<StatCard label='Version'>v{health.version}</StatCard>
+						<StatCard label='Environment'>{health.environment}</StatCard>
+						<StatCard label='Current Season'>{health.currentSeason}</StatCard>
+						<StatCard label='Uptime'>{formatUptime(health.uptime)}</StatCard>
+						<StatCard label='Server Time'>
+							{new Date(health.currentTime).toLocaleString()}
+						</StatCard>
+					</div>
+				</section>
+
+				<section className={styles['diagnostics-section']}>
+					<h2 className={styles['diagnostics-section__title']}>Cache Usage</h2>
+					<div className={styles['cache-card']}>
+						<div className={styles['cache-summary']}>
+							<div className={styles['cache-summary__item']}>
+								<span className={styles['cache-summary__label']}>Total</span>
+								<span className={styles['cache-summary__value']}>
+									{formatBytes(cacheReport.total)}
+								</span>
+							</div>
+							<div className={styles['cache-summary__item']}>
+								<span className={styles['cache-summary__label']}>
+									Largest Section
+								</span>
+								<span className={styles['cache-summary__value']}>
+									{cacheReport.largestSection.type ?? '—'}
+								</span>
+							</div>
+						</div>
+						<table className={styles['cache-table']}>
+							<thead>
+								<tr>
+									<th className={styles['cache-table__section-col']}>
+										Section
+									</th>
+									<th>Size</th>
+									<th className={styles['cache-table__bar-col']}>Share</th>
+								</tr>
+							</thead>
+							<tbody>
+								{sectionRows.map(([type, size]) => {
+									const pct =
+										cacheReport.total ? (size / cacheReport.total) * 100 : 0;
+									const isLargest = type === cacheReport.largestSection.type;
+									return (
+										<tr
+											key={type}
+											className={cx(
+												isLargest && styles['cache-table__row--largest'],
+											)}
+										>
+											<td className={styles['cache-table__section-col']}>
+												{type}
+											</td>
+											<td>{formatBytes(size)}</td>
+											<td className={styles['cache-table__bar-col']}>
+												<span className={styles['cache-bar-track']}>
+													<span
+														className={styles['cache-bar-fill']}
+														style={{ width: `${pct}%` }}
+													/>
+												</span>
+												<span className={styles['cache-bar__pct']}>
+													{pct.toFixed(0)}%
+												</span>
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				</section>
+			</div>
+		);
+	};
+
+	return (
+		<div className={styles['diagnostics-page']}>
+			<PageHeader />
+			{loading && !authed ?
+				<LoadingState label='Loading diagnostics' fullPage />
+			: authed ?
+				renderContent()
+			:	renderGate()}
+		</div>
+	);
+};
+
+export default DiagnosticsPage;

--- a/react/src/Services/ApiHandler.ts
+++ b/react/src/Services/ApiHandler.ts
@@ -1,124 +1,160 @@
-import { axiosExpressHandler } from "./AxiosInstance"
-export async function GetCurrentStandings(){
-    try{
-        const response =  await axiosExpressHandler.get("/standings");
-        return response.data;
-    }catch(error){
-        console.error("Error fetching data: ", error);
-        throw error;
-    }
+import { axiosExpressHandler } from './AxiosInstance';
+export async function GetCurrentStandings() {
+	try {
+		const response = await axiosExpressHandler.get('/standings');
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching data: ', error);
+		throw error;
+	}
 }
-export async function GetSkaterStatLeaders(statIndicator:string){
-    try{
-        const response = await axiosExpressHandler.get("/player/skater/statLeaders/"+ statIndicator);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching data: ", error);
-        throw error;
-    }
+export async function GetSkaterStatLeaders(statIndicator: string) {
+	try {
+		const response = await axiosExpressHandler.get(
+			'/player/skater/statLeaders/' + statIndicator,
+		);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching data: ', error);
+		throw error;
+	}
 }
-export async function GetGoalieStatLeaders(statIndicator:string){
-    try{
-        const response =  await axiosExpressHandler.get("/player/goalie/statLeaders/" + statIndicator);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching data: ", error);
-        throw error;
-    }
+export async function GetGoalieStatLeaders(statIndicator: string) {
+	try {
+		const response = await axiosExpressHandler.get(
+			'/player/goalie/statLeaders/' + statIndicator,
+		);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching data: ', error);
+		throw error;
+	}
 }
-export async function GetListOfTeams(){
-    try{
-        const response = await axiosExpressHandler.get("/team/");
-        return response.data;
-    }catch(error){
-        console.error("Error fetching data: ", error);
-        throw error;
-    }
+export async function GetListOfTeams() {
+	try {
+		const response = await axiosExpressHandler.get('/team/');
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching data: ', error);
+		throw error;
+	}
 }
-export async function GetTeamStatsById(teamId:string){
-    try{
-        const response = await axiosExpressHandler.get("/team/" + teamId);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching data: ", error);
-        throw error;
-    }
+export async function GetTeamStatsById(teamId: string) {
+	try {
+		const response = await axiosExpressHandler.get('/team/' + teamId);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching data: ', error);
+		throw error;
+	}
 }
-export async function GetScheduledGames(){
-    try{
-        const response = await axiosExpressHandler.get("/schedule/");
-        return response.data;
-    }catch(error){
-        console.error("Error fetching data: ", error);
-        throw error;
-    }
+export async function GetScheduledGames() {
+	try {
+		const response = await axiosExpressHandler.get('/schedule/');
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching data: ', error);
+		throw error;
+	}
 }
 export async function GetGameLanding(gameID: number) {
-    try{
-        const response = await axiosExpressHandler.get(`/schedule/landing/${gameID}`);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching data: ", error);
-        throw error;
-    }
- }
-export async function GetGameDetails(gameID:number){
-    try{
-        const response = await axiosExpressHandler.get(`/schedule/${gameID}`);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching data: ", error);
-        throw error;
-    }
+	try {
+		const response = await axiosExpressHandler.get(
+			`/schedule/landing/${gameID}`,
+		);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching data: ', error);
+		throw error;
+	}
+}
+export async function GetGameDetails(gameID: number) {
+	try {
+		const response = await axiosExpressHandler.get(`/schedule/${gameID}`);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching data: ', error);
+		throw error;
+	}
 }
 export async function GetTeamRoster(triCode: string) {
-    try{
-        const response = await axiosExpressHandler.get(`/team/roster/${triCode}`);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching team roster: ", error);
-        throw error;
-    }
+	try {
+		const response = await axiosExpressHandler.get(`/team/roster/${triCode}`);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching team roster: ', error);
+		throw error;
+	}
 }
 export async function GetTeamSchedule(triCode: string) {
-    try{
-        const response = await axiosExpressHandler.get(`/team/schedule/${triCode}`);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching team schedule: ", error);
-        throw error;
-    }
+	try {
+		const response = await axiosExpressHandler.get(`/team/schedule/${triCode}`);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching team schedule: ', error);
+		throw error;
+	}
 }
 export async function GetSkaterSummary(teamId?: string) {
-    try{
-        const url = teamId ? `/player/skater/summary?teamId=${teamId}` : "/player/skater/summary";
-        const response = await axiosExpressHandler.get(url);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching skater summary: ", error);
-        throw error;
-    }
+	try {
+		const url =
+			teamId ?
+				`/player/skater/summary?teamId=${teamId}`
+			:	'/player/skater/summary';
+		const response = await axiosExpressHandler.get(url);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching skater summary: ', error);
+		throw error;
+	}
 }
 export async function GetSkaterCorsi(teamId?: string) {
-    try{
-        const url = teamId ? `/player/skater/corsi?teamId=${teamId}` : "/player/skater/corsi";
-        const response = await axiosExpressHandler.get(url);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching skater corsi: ", error);
-        throw error;
-    }
+	try {
+		const url =
+			teamId ? `/player/skater/corsi?teamId=${teamId}` : '/player/skater/corsi';
+		const response = await axiosExpressHandler.get(url);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching skater corsi: ', error);
+		throw error;
+	}
 }
 export async function GetGoalieSummary(teamId?: string) {
-    try{
-        const url = teamId ? `/player/goalie/summary?teamId=${teamId}` : "/player/goalie/summary";
-        const response = await axiosExpressHandler.get(url);
-        return response.data;
-    }catch(error){
-        console.error("Error fetching goalie summary: ", error);
-        throw error;
-    }
+	try {
+		const url =
+			teamId ?
+				`/player/goalie/summary?teamId=${teamId}`
+			:	'/player/goalie/summary';
+		const response = await axiosExpressHandler.get(url);
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching goalie summary: ', error);
+		throw error;
+	}
 }
-export async function GetDraft(){
-    // return axiosNhl.get("/draft")
+export async function GetDraft() {
+	// return axiosNhl.get("/draft")
+}
+const DIAGNOSTICS_HEADER = 'x-diagnostics-key';
+export async function GetHealth(passphrase: string) {
+	try {
+		const response = await axiosExpressHandler.get('/health', {
+			headers: { [DIAGNOSTICS_HEADER]: passphrase },
+		});
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching health: ', error);
+		throw error;
+	}
+}
+export async function GetCacheReport(passphrase: string) {
+	try {
+		const response = await axiosExpressHandler.get('/health/cache-usage', {
+			headers: { [DIAGNOSTICS_HEADER]: passphrase },
+		});
+		return response.data;
+	} catch (error) {
+		console.error('Error fetching cache report: ', error);
+		throw error;
+	}
 }

--- a/react/src/style/DiagnosticsPage.module.css
+++ b/react/src/style/DiagnosticsPage.module.css
@@ -1,0 +1,394 @@
+/* ── Page shell ─────────────────────────────────────────────────────────── */
+
+.diagnostics-page {
+  min-height: 100vh;
+  background: var(--color-bg-subtle);
+  padding-bottom: var(--space-xl);
+}
+
+.diagnostics-page__content {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: var(--space-xl) var(--space-lg) 0;
+}
+
+/* ── Header row (title + actions) ───────────────────────────────────────── */
+
+.diagnostics-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-lg);
+}
+
+.diagnostics-title {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.diagnostics-actions {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.diagnostics-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-md);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-primary) 4%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent);
+  border-radius: var(--border-radius-pill);
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.15s ease;
+}
+
+.diagnostics-icon-btn:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface));
+  box-shadow: var(--shadow-card);
+  transform: translateY(-1px);
+}
+
+.diagnostics-icon-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+/* ── Passphrase gate ────────────────────────────────────────────────────── */
+
+.diagnostics-gate-wrap {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+}
+
+.diagnostics-gate {
+  width: 100%;
+  max-width: 26rem;
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+  text-align: center;
+  background: color-mix(in srgb, var(--color-primary) 4%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent);
+  border-radius: var(--border-radius-card);
+  box-shadow: var(--shadow-card);
+}
+
+.diagnostics-gate__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+}
+
+.diagnostics-gate__title {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.diagnostics-gate__desc {
+  font-size: var(--text-sm);
+  color: var(--color-muted-text);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.diagnostics-gate__form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-top: var(--space-xs);
+}
+
+.diagnostics-gate__input {
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--text-base);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 28%, transparent);
+  border-radius: var(--border-radius-card);
+  outline: none;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.diagnostics-gate__input::placeholder {
+  color: var(--color-muted-text);
+}
+
+.diagnostics-gate__input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 22%, transparent);
+}
+
+.diagnostics-gate__button {
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-white);
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--border-radius-pill);
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.15s ease;
+}
+
+.diagnostics-gate__button:hover:not(:disabled) {
+  background: var(--color-primary-dark);
+  box-shadow: var(--shadow-card);
+  transform: translateY(-1px);
+}
+
+.diagnostics-gate__button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.diagnostics-gate__error {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-danger);
+  margin: 0;
+}
+
+/* ── Sections ───────────────────────────────────────────────────────────── */
+
+.diagnostics-section {
+  margin-bottom: var(--space-xl);
+}
+
+.diagnostics-section__title {
+  font-size: 1.375rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0 0 var(--space-md);
+}
+
+/* ── Status grid ────────────────────────────────────────────────────────── */
+
+.diagnostics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+  gap: var(--space-md);
+}
+
+.diagnostics-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-md) var(--space-lg);
+  background: color-mix(in srgb, var(--color-primary) 4%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent);
+  border-radius: var(--border-radius-card);
+}
+
+.diagnostics-stat-card__label {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-muted-text);
+}
+
+.diagnostics-stat-card__value {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--color-text);
+  text-transform: capitalize;
+}
+
+/* ── Status badge ───────────────────────────────────────────────────────── */
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 4px 12px;
+  border-radius: var(--border-radius-pill);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.25px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.status-badge__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-badge--ok {
+  color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 15%, transparent);
+}
+
+.status-badge--bad {
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 15%, transparent);
+}
+
+/* ── Cache usage card + table ───────────────────────────────────────────── */
+
+.cache-card {
+  background: color-mix(in srgb, var(--color-primary) 4%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent);
+  border-radius: var(--border-radius-card);
+  overflow: hidden;
+}
+
+.cache-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xl);
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--color-divider);
+  background: color-mix(in srgb, var(--color-primary) 7%, var(--color-surface));
+}
+
+.cache-summary__item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cache-summary__label {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-muted-text);
+}
+
+.cache-summary__value {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--color-primary);
+  text-transform: capitalize;
+}
+
+.cache-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.cache-table th,
+.cache-table td {
+  padding: var(--space-sm) var(--space-lg);
+  text-align: center;
+  border-bottom: 1px solid var(--color-subtle-divider);
+}
+
+.cache-table th {
+  color: var(--color-muted-text);
+  font-weight: 700;
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  background: transparent;
+}
+
+.cache-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.cache-table__section-col {
+  text-align: left !important;
+  font-weight: 600;
+  color: var(--color-text);
+  text-transform: capitalize;
+}
+
+.cache-table__row--largest .cache-table__section-col {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+.cache-table__bar-col {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-width: 9rem;
+}
+
+.cache-bar-track {
+  flex: 1;
+  height: 6px;
+  border-radius: var(--border-radius-pill);
+  background: var(--color-chip-bg);
+  overflow: hidden;
+}
+
+.cache-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--border-radius-pill);
+  background: color-mix(in srgb, var(--color-primary) 55%, var(--color-muted-text));
+  transition: width 0.3s ease;
+}
+
+.cache-table__row--largest .cache-bar-fill {
+  background: var(--color-primary);
+}
+
+.cache-bar__pct {
+  min-width: 2.5rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-muted-text);
+  font-weight: 600;
+}
+
+/* ── Dark mode: lift primary-on-dark text for readability ───────────────── */
+
+[data-theme="dark"] .cache-summary__value,
+[data-theme="dark"] .cache-table__row--largest .cache-table__section-col {
+  color: color-mix(in srgb, var(--color-primary) 70%, white);
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .diagnostics-page__content {
+    padding: var(--space-lg) var(--space-md) 0;
+  }
+
+  .cache-table th,
+  .cache-table td {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .cache-table__bar-col {
+    min-width: 6rem;
+  }
+}


### PR DESCRIPTION
  Backend
  - New GET /health route module (api/routes/health.js) returning status, version, environment, currentSeason, cacheWritable, anthropicKeyConfigured, uptime, and currentTime.
  - New GET /health/cache-usage returning per-section cache sizes, the largest section, and the total.
  - cacheManager helpers isCacheWritable() and getCacheUsage() (+ dirSize()).
  - Passphrase auth in api/utils/auth.js: constant-time crypto.timingSafeEqual comparison against DIAGNOSTICS_PASSPHRASE (fails closed if unset), exposed as an authCheck middleware guarding the whole /health router.
  - x-diagnostics-key added to CORS allowedHeaders.

  Frontend
  - GetHealth() and GetCacheReport() service functions in ApiHandler.ts, sending the passphrase via the x-diagnostics-key header.
  - New unlinked /diagnostics route + DiagnosticsPage with a passphrase gate, MD3 status grid, and cache-usage table. Passphrase persists in sessionStorage for the tab; 401s and unreachable-API errors are handled gracefully without
  crashing the app.

  Docs
  - Documented the diagnostics layer in docs/architecture.md.
  - Checked off 2.1 in docs/phase-2-backlog.md and started docs/phase-2-progress.md.