### PR TITLE
[2.2] - Normalize API response contracts

### DIFF
--- a/api/routes/player.js
+++ b/api/routes/player.js
@@ -2,18 +2,23 @@ var express = require("express");
 const { getCurrentSeasonId } = require("../utils/seasonHelper");
 const { axiosNhl, axiosNhlStats, axiosNhlGoalie } = require("../services/nhlApiClient");
 const { GetOrFetch, CACHE_TYPES } = require("../utils/cacheManager");
+const {
+  mapSkaterSummary,
+  mapGoalieSummary,
+  mapStatLeaders,
+} = require("../services/mappers/playerMapper");
 
 var router = express.Router();
 
 router.get("/skater/statLeaders/:statIndicator", async function (req, res, next) {
   try {
     const { statIndicator } = req.params;
-    const data = await GetOrFetch(
+    const raw = await GetOrFetch(
       CACHE_TYPES.STAT_LEADERS,
       `skater_${statIndicator}`,
       () => axiosNhl.get(`/skater-stats-leaders/current?categories=${statIndicator}&limit=10`).then(r => r.data)
     );
-    res.send(data);
+    res.send(mapStatLeaders(raw, statIndicator));
   } catch (e) {
     next(e);
   }
@@ -22,12 +27,12 @@ router.get("/skater/statLeaders/:statIndicator", async function (req, res, next)
 router.get("/goalie/statLeaders/:statIndicator", async function (req, res, next) {
   try {
     const { statIndicator } = req.params;
-    const data = await GetOrFetch(
+    const raw = await GetOrFetch(
       CACHE_TYPES.STAT_LEADERS,
       `goalie_${statIndicator}`,
       () => axiosNhl.get(`/goalie-stats-leaders/current?categories=${statIndicator}&limit=10`).then(r => r.data)
     );
-    res.send(data);
+    res.send(mapStatLeaders(raw, statIndicator));
   } catch (e) {
     next(e);
   }
@@ -40,12 +45,12 @@ router.get("/skater/summary", async function (req, res, next) {
     const seasonId = season || getCurrentSeasonId();
     let exp = `seasonId=${seasonId} and gameTypeId=2`;
     if (teamId) exp += ` and teamId=${teamId}`;
-    const data = await GetOrFetch(
+    const raw = await GetOrFetch(
       CACHE_TYPES.PLAYER,
       `skater_summary_${teamId || "all"}_${seasonId}`,
       () => axiosNhlStats.get(`/summary?cayenneExp=${encodeURIComponent(exp)}&limit=100`).then(r => r.data)
     );
-    res.send(data);
+    res.send(mapSkaterSummary(raw));
   } catch (e) {
     next(e);
   }
@@ -75,12 +80,12 @@ router.get("/goalie/summary", async function (req, res, next) {
     const seasonId = season || getCurrentSeasonId();
     let exp = `seasonId=${seasonId} and gameTypeId=2`;
     if (teamId) exp += ` and teamId=${teamId}`;
-    const data = await GetOrFetch(
+    const raw = await GetOrFetch(
       CACHE_TYPES.PLAYER,
       `goalie_summary_${teamId || "all"}_${seasonId}`,
       () => axiosNhlGoalie.get(`/summary?cayenneExp=${encodeURIComponent(exp)}&limit=10`).then(r => r.data)
     );
-    res.send(data);
+    res.send(mapGoalieSummary(raw));
   } catch (e) {
     next(e);
   }

--- a/api/routes/schedule.js
+++ b/api/routes/schedule.js
@@ -1,8 +1,25 @@
 var express = require("express");
 const { axiosNhl } = require("../services/nhlApiClient");
 const { GetOrFetch, writeCache, CACHE_TYPES } = require("../utils/cacheManager");
+const { mapGame } = require("../services/mappers/scheduleMapper");
 
 var router = express.Router();
+
+/**
+ * Flatten the raw weekly season payload into a list of ScheduleGameContract.
+ * The week supplies date/dayAbbrev; each of its games is mapped with that ctx.
+ * @param {{ gameWeek?: any[] }} raw
+ * @returns {import("../services/mappers/scheduleMapper").ScheduleGameContract[]}
+ */
+function mapSeasonSchedule(raw) {
+  const games = [];
+  for (const week of raw?.gameWeek ?? []) {
+    for (const g of week.games ?? []) {
+      games.push(mapGame(g, { date: week.date, dayAbbrev: week.dayAbbrev }));
+    }
+  }
+  return games;
+}
 
 async function fetchSeasonSchedule() {
   const today = new Date();
@@ -41,8 +58,8 @@ async function refreshScheduleCache() {
 
 router.get("/", async function (req, res, next) {
   try {
-    const data = await GetOrFetch(CACHE_TYPES.SCHEDULE, 'season', fetchSeasonSchedule);
-    res.send(data);
+    const raw = await GetOrFetch(CACHE_TYPES.SCHEDULE, 'season', fetchSeasonSchedule);
+    res.send({ games: mapSeasonSchedule(raw) });
   } catch (e) {
     next(e);
   }

--- a/api/routes/standings.js
+++ b/api/routes/standings.js
@@ -1,22 +1,22 @@
 var express = require("express");
 const { axiosNhl } = require("../services/nhlApiClient");
 const { GetOrFetch, CACHE_TYPES } = require("../utils/cacheManager");
+const { mapStandingsTeam } = require("../services/mappers/standingsMapper");
 
 var router = express.Router();
 
 async function fetchStandings() {
   const response = await axiosNhl.get("/standings/now");
-  const standings = response.data.standings?.map((team) => ({
-    ...team,
-    clinchingIndicator: team.clinchingIndicator ?? team.clinchIndicator ?? "",
-  }));
-  return { ...response.data, standings };
+  return response.data;
 }
 
 router.get("/", async function (req, res, next) {
   try {
     const data = await GetOrFetch(CACHE_TYPES.STANDINGS, 'current', fetchStandings);
-    res.send(data);
+    const standings = (data.standings ?? [])
+      .map(mapStandingsTeam)
+      .filter(Boolean);
+    res.send({ ...data, standings });
   } catch (e) {
     next(e);
   }

--- a/api/routes/team.js
+++ b/api/routes/team.js
@@ -2,19 +2,33 @@ var express = require("express");
 const { getCurrentSeasonId } = require("../utils/seasonHelper");
 const { axiosNhl, axiosNhlTeam } = require("../services/nhlApiClient");
 const { GetOrFetch, CACHE_TYPES } = require("../utils/cacheManager");
+const { mapRoster } = require("../services/mappers/rosterMapper");
+const { mapGame } = require("../services/mappers/scheduleMapper");
 
 var router = express.Router();
+
+/**
+ * Local-time-aware short weekday for a YYYY-MM-DD club-schedule date.
+ * (The club-schedule endpoint has no dayAbbrev like the weekly endpoint does.)
+ * @param {string} gameDate
+ * @returns {string}
+ */
+function shortDayOfWeek(gameDate) {
+  return new Date(`${gameDate}T12:00:00`).toLocaleDateString("en-US", {
+    weekday: "short",
+  });
+}
 
 router.get("/roster/:triCode", async function (req, res, next) {
   try {
     const { triCode } = req.params;
     const season = getCurrentSeasonId();
-    const data = await GetOrFetch(
+    const raw = await GetOrFetch(
       CACHE_TYPES.ROSTER,
       `${triCode}_${season}`,
       () => axiosNhl.get(`/roster/${triCode}/${season}`).then(r => r.data)
     );
-    res.send(data);
+    res.send(mapRoster(raw));
   } catch (e) {
     next(e);
   }
@@ -25,7 +39,15 @@ router.get("/schedule/:triCode", async function (req, res, next) {
     const { triCode } = req.params;
     const season = req.query.season || getCurrentSeasonId();
     const response = await axiosNhl.get(`/club-schedule-season/${triCode}/${season}`);
-    res.send(response.data);
+    const games = (response.data.games ?? [])
+      .map((g) =>
+        mapGame(g, { date: g.gameDate, dayAbbrev: shortDayOfWeek(g.gameDate) }),
+      )
+      .sort((a, b) =>
+        new Date(`${a.date}T12:00:00`).getTime() -
+        new Date(`${b.date}T12:00:00`).getTime(),
+      );
+    res.send({ games });
   } catch (e) {
     next(e);
   }

--- a/api/services/mappers/playerMapper.js
+++ b/api/services/mappers/playerMapper.js
@@ -1,0 +1,127 @@
+/**
+ * playerMapper
+ *
+ * Translates the NHL stats/leaders payloads into stable contracts:
+ *   - mapSkaterSummary  (rest/en/skater/summary -> data[])
+ *   - mapGoalieSummary  (rest/en/goalie/summary -> data[])
+ *   - mapStatLeaders    (api-web skater/goalie-stats-leaders, keyed by category)
+ *
+ * Field sourcing mirrors TeamPage.tsx (transformPlayerStats + goalie toiMap loop)
+ * and react/src/Data/Helpers/PlayerStatLeaderConverter.ts.
+ *
+ * Scope note: corsi (SAT%) comes from a SEPARATE endpoint and is merged on the
+ * frontend by playerId — it is intentionally NOT part of the skater contract.
+ */
+
+/**
+ * @typedef {Object} SkaterSummaryContract
+ * @property {number}      playerId
+ * @property {string}      name            - skaterFullName
+ * @property {string}      position        - positionCode
+ * @property {number}      gamesPlayed
+ * @property {number}      goals
+ * @property {number}      assists
+ * @property {number}      points
+ * @property {number}      plusMinus
+ * @property {number}      penaltyMinutes
+ * @property {number|null} faceoffWinPct   - NULL when 0 (player takes no faceoffs)
+ * @property {number|null} toiPerGame      - timeOnIcePerGame (seconds), for roster TOI merge
+ */
+
+/**
+ * @typedef {Object} GoalieSummaryContract
+ * @property {number}      goalieId
+ * @property {string}      name            - goalieFullName
+ * @property {number}      gamesPlayed
+ * @property {number}      wins
+ * @property {number}      losses
+ * @property {number|null} savePctg
+ * @property {number|null} goalsAgainstAverage
+ * @property {number}      shutouts
+ * @property {number|null} toiPerGame      - timeOnIcePerGame (seconds)
+ */
+
+/**
+ * @typedef {Object} StatLeaderContract
+ * @property {number}      id
+ * @property {string}      firstName       - firstName.default (guarded -> "")
+ * @property {string}      lastName        - lastName.default (guarded -> "")
+ * @property {number|null} sweaterNumber
+ * @property {string}      headshot
+ * @property {string}      teamAbbrev
+ * @property {string}      teamName        - teamName.default (guarded -> "")
+ * @property {string}      teamLogo
+ * @property {string}      position
+ * @property {number}      value           - the category's stat value
+ */
+
+/**
+ * Map the NHL skater summary payload into contract rows.
+ * @param {any} raw - { data: [...] }
+ * @returns {SkaterSummaryContract[]}
+ */
+function mapSkaterSummary(raw) {
+  return (raw?.data ?? []).map((p) => ({
+    playerId: p.playerId,
+    name: p.skaterFullName ?? "",
+    position: p.positionCode ?? "",
+    gamesPlayed: p.gamesPlayed ?? 0,
+    goals: p.goals ?? 0,
+    assists: p.assists ?? 0,
+    points: p.points ?? 0,
+    plusMinus: p.plusMinus ?? 0,
+    penaltyMinutes: p.penaltyMinutes ?? 0,
+    // NHL returns 0 for players who take no faceoffs — treat that as N/A, not 0%.
+    faceoffWinPct: p.faceoffWinPct > 0 ? p.faceoffWinPct : null,
+    toiPerGame: p.timeOnIcePerGame ?? null,
+  }));
+}
+
+/**
+ * Map the NHL goalie summary payload into contract rows.
+ * @param {any} raw - { data: [...] }
+ * @returns {GoalieSummaryContract[]}
+ */
+function mapGoalieSummary(raw) {
+  return (raw?.data ?? []).map((g) => ({
+    // NOTE: the frontend read `goalieId`; the rest endpoint may also expose
+    // `playerId`. Accept either so the TOI merge stays robust.
+    goalieId: g.goalieId ?? g.playerId,
+    name: g.goalieFullName ?? "",
+    gamesPlayed: g.gamesPlayed ?? 0,
+    wins: g.wins ?? 0,
+    losses: g.losses ?? 0,
+    savePctg: g.savePct ?? null,
+    goalsAgainstAverage: g.goalsAgainstAverage ?? null,
+    shutouts: g.shutouts ?? 0,
+    toiPerGame: g.timeOnIcePerGame ?? null,
+  }));
+}
+
+/**
+ * Map a stat-leaders payload for a single category into contract rows.
+ * The raw payload is keyed by category (goals, assists, wins, savePctg, ...);
+ * select raw[category], then map each entry. Guards every `.default` unwrap.
+ * @param {any} raw
+ * @param {string} category - e.g. "goals" | "assists" | "wins" | "savePctg"
+ * @returns {StatLeaderContract[]}
+ */
+function mapStatLeaders(raw, category) {
+  const list = raw?.[category];
+  if (!Array.isArray(list)) return [];
+
+  return list.map((p) => ({
+    id: p.id,
+    firstName: p.firstName?.default ?? "",
+    lastName: p.lastName?.default ?? "",
+    sweaterNumber: p.sweaterNumber ?? null,
+    headshot: p.headshot ?? "",
+    teamAbbrev: p.teamAbbrev ?? "",
+    teamName: p.teamName?.default ?? "",
+    teamLogo: p.teamLogo ?? "",
+    position: p.position ?? "",
+    value: p.value,
+  }));
+}
+
+module.exports = { mapSkaterSummary, mapGoalieSummary, mapStatLeaders };

--- a/api/services/mappers/rosterMapper.js
+++ b/api/services/mappers/rosterMapper.js
@@ -1,0 +1,60 @@
+/**
+ * rosterMapper
+ *
+ * Flattens the NHL roster (forwards/defensemen/goalies) into a single, stable
+ * list of RosterPlayerContract entries.
+ * Field sourcing mirrors react/src/Data/Helpers ../Pages/TeamPage.tsx transformRoster.
+ *
+ * Scope note: keeps the raw position CODE (C/L/R/D/G). The "Center"/"Left Wing"
+ * display labels (POS_MAP) and TOI formatting stay on the frontend. TOI itself
+ * comes from a DIFFERENT endpoint (skater/goalie summary), so it is NOT included
+ * here — the frontend merges it in by player id.
+ */
+
+/**
+ * @typedef {Object} RosterPlayerContract
+ * @property {number} id
+ * @property {string} name          - "firstName.default lastName.default", trimmed
+ * @property {number} number        - sweaterNumber (defensive: 0 if missing)
+ * @property {string} position      - raw positionCode: C | L | R | D | G
+ * @property {string} headshot      - "" if missing
+ */
+
+/**
+ * @typedef {Object} RosterContract
+ * @property {RosterPlayerContract[]} players
+ */
+
+/**
+ * Map one raw NHL roster player (from any position bucket) into a contract.
+ * @param {any} rawPlayer
+ * @returns {RosterPlayerContract}
+ */
+function mapRosterPlayer(rawPlayer) {
+  const id = rawPlayer.id;
+  const name =
+    `${rawPlayer.firstName?.default ?? ""} ${rawPlayer.lastName?.default ?? ""}`.trim();
+  const number = rawPlayer.sweaterNumber ?? 0;
+  const position = rawPlayer.positionCode ?? "";
+  const headshot = rawPlayer.headshot ?? "";
+
+  return { id, name, number, position, headshot };
+}
+
+/**
+ * Flatten the raw NHL roster into a RosterContract.
+ * @param {any} rawRoster - { forwards, defensemen, goalies }
+ * @returns {RosterContract}
+ */
+function mapRoster(rawRoster) {
+  const all = [
+    ...(rawRoster?.forwards ?? []),
+    ...(rawRoster?.defensemen ?? []),
+    ...(rawRoster?.goalies ?? []),
+  ];
+  const players = all.map(mapRosterPlayer);
+
+  return { players };
+}
+
+module.exports = { mapRoster, mapRosterPlayer };

--- a/api/services/mappers/scheduleMapper.js
+++ b/api/services/mappers/scheduleMapper.js
@@ -1,0 +1,143 @@
+/**
+ * scheduleMapper
+ *
+ * Translates raw NHL schedule games into the app's stable ScheduleGameContract.
+ * Serves BOTH schedule sources, which supply the date differently:
+ *   - /schedule/        -> weekly endpoint, games nested under gameWeek[].games[],
+ *                          date/dayAbbrev live on the WEEK (pass them in via ctx).
+ *   - /team/schedule/.. -> club-schedule endpoint, each game has its own gameDate.
+ *
+ * Field sourcing mirrors react/src/Data/Helpers/ScheduleHelper.ts so the moved
+ * logic stays behaviorally identical. All NHL-field knowledge lives here ONCE;
+ * the frontend consumes this contract, never raw NHL JSON.
+ */
+
+/**
+ * @typedef {Object} GameBroadcastContract
+ * @property {number|null} id
+ * @property {string}      network       - NHL "network" (defensive: "" if missing)
+ * @property {string}      market        - e.g. "N" (national) / "H" / "A"
+ * @property {string}      countryCode
+ */
+
+/**
+ * @typedef {Object} ScheduleGameContract
+ * @property {number}      gameId
+ * @property {string}      date          - YYYY-MM-DD (week date or game's gameDate)
+ * @property {string}      gameTime      - startTimeUTC
+ * @property {string}      dayOfWeek     - dayAbbrev (e.g. "Mon")
+ * @property {string}      venue
+ * @property {string}      homeTeam      - abbrev
+ * @property {string}      homeLogo
+ * @property {number|null} homeScore
+ * @property {string}      awayTeam      - abbrev
+ * @property {string}      awayLogo
+ * @property {number|null} awayScore
+ * @property {GameBroadcastContract[]} broadcasts
+ * @property {string}      ticketLink    - only for future games, else ""
+ * @property {string}      gameCenter    - gameCenterLink
+ * @property {boolean}     isPlayoff     - gameType === 3
+ * @property {number|null} playoffRound
+ * @property {string|null} periodType    - periodDescriptor.periodType
+ * @property {string|null} seriesWins    - "top-bottom" wins, e.g. "3-2"
+ * @property {string|null} topSeedTeamAbbrev
+ * @property {string|null} bottomSeedTeamAbbrev
+ * @property {string}      gameState     - FUT / PRE / OFF / FINAL ...
+ */
+
+/**
+ * Map raw NHL tvBroadcasts into broadcast contracts.
+ * Mirrors ScheduleHelper.ts -> ConvertToListOfBroadcasts.
+ * @param {any[]} [rawBroadcasts]
+ * @returns {GameBroadcastContract[]}
+ */
+function mapBroadcasts(rawBroadcasts = []) {
+  return rawBroadcasts.filter(Boolean).map((b) => {
+    const id = b.id ?? null;
+    const network = b.network ?? "";
+    const market = b.market ?? "";
+    const countryCode = b.countryCode ?? "";
+
+    return { id, network, market, countryCode };
+  });
+}
+
+/**
+ * Derive the playoff round.
+ * Prefer seriesStatus.round; fall back to digits 7-8 of a 10-char game id.
+ * @param {any} rawGame
+ * @returns {number|null}
+ */
+function derivePlayoffRound(rawGame) {
+  if (rawGame.seriesStatus?.round != null) {
+    return rawGame.seriesStatus.round;
+  }
+  const idStr = String(rawGame.id ?? "");
+  return idStr.length === 10 ? parseInt(idStr.slice(6, 8)) || null : null;
+}
+
+/**
+ * Map a single raw NHL game into a ScheduleGameContract.
+ * Mirrors ScheduleHelper.ts -> ConvertWeekToGames (one game iteration).
+ * @param {any} rawGame
+ * @param {{ date: string, dayAbbrev: string }} ctx - date/day supplied by the caller
+ * @returns {ScheduleGameContract}
+ */
+function mapGame(rawGame, ctx) {
+  const gameState = rawGame.gameState;
+  const gameId = rawGame.id;
+  const date = ctx.date;
+  const gameTime = rawGame.startTimeUTC;
+  const dayOfWeek = ctx.dayAbbrev;
+  const venue = rawGame.venue?.default ?? "";
+  const homeTeam = rawGame.homeTeam?.abbrev ?? "";
+  const homeLogo = rawGame.homeTeam?.logo ?? "";
+  const homeScore = rawGame.homeTeam?.score ?? null;
+  const awayTeam = rawGame.awayTeam?.abbrev ?? "";
+  const awayLogo = rawGame.awayTeam?.logo ?? "";
+  const awayScore = rawGame.awayTeam?.score ?? null;
+  const broadcasts = mapBroadcasts(rawGame.tvBroadcasts);
+  const ticketLink = gameState === "FUT" ? (rawGame.ticketsLink ?? "") : "";
+  const gameCenter = rawGame.gameCenterLink ?? "";
+  const isPlayoff = rawGame.gameType === 3;
+  const periodType = rawGame.periodDescriptor?.periodType ?? null;
+
+  const series = rawGame.seriesStatus;
+  const playoffRound = isPlayoff ? derivePlayoffRound(rawGame) : null;
+  const topSeedTeamAbbrev = isPlayoff ? (series?.topSeedTeamAbbrev ?? null) : null;
+  const bottomSeedTeamAbbrev = isPlayoff
+    ? (series?.bottomSeedTeamAbbrev ?? null)
+    : null;
+  const seriesWins = (() => {
+    if (!isPlayoff) return null;
+    const top = series?.topSeedWins;
+    const bot = series?.bottomSeedWins;
+    return top != null && bot != null ? `${top}-${bot}` : null;
+  })();
+
+  return /** @type {ScheduleGameContract} */ ({
+    gameId,
+    date,
+    gameTime,
+    dayOfWeek,
+    venue,
+    homeTeam,
+    homeLogo,
+    homeScore,
+    awayTeam,
+    awayLogo,
+    awayScore,
+    broadcasts,
+    ticketLink,
+    gameCenter,
+    isPlayoff,
+    playoffRound,
+    periodType,
+    seriesWins,
+    topSeedTeamAbbrev,
+    bottomSeedTeamAbbrev,
+    gameState,
+  });
+}
+
+module.exports = { mapGame, mapBroadcasts, derivePlayoffRound };

--- a/api/services/mappers/standingsMapper.js
+++ b/api/services/mappers/standingsMapper.js
@@ -1,0 +1,101 @@
+/**
+ * standingsMapper
+ *
+ * Translates a raw NHL standings row into the app's StandingsTeamContract.
+ * Field sourcing mirrors react/src/Data/Helpers/LeagueStandingsHelper.ts.
+ *
+ * Scope note: this mapper does SHAPE translation only (raw field extraction,
+ * id fallback chain, clinch-indicator spelling). App/derived logic stays on the
+ * frontend (draft-lottery odds + trend, pointsPctg rounding, playoff-line delta).
+ */
+
+/**
+ * @typedef {Object} StandingsTeamContract
+ * @property {string|number} teamId          - resolved via fallback chain below
+ * @property {string}      teamLogo
+ * @property {string}      name              - teamCommonName.default
+ * @property {string}      conferenceName
+ * @property {string}      divisionName
+ * @property {number}      wins
+ * @property {number}      losses
+ * @property {number}      otLosses
+ * @property {number}      points
+ * @property {number}      pointPctg         - raw NHL fraction (frontend rounds for display)
+ * @property {number}      leagueSequence
+ * @property {number}      conferenceSequence
+ * @property {number}      divisionSequence
+ * @property {number}      wildcardSequence
+ * @property {string}      clinchingIndicator - clinchingIndicator || clinchIndicator || ""
+ * @property {number}      leagueL10Sequence  - last-10 league rank (frontend lottery trend)
+ */
+
+/**
+ * Resolve the team identifier across the NHL's inconsistent shapes.
+ * Order: teamAbbrev.default -> teamId.id -> teamId -> id -> team.id
+ * @param {any} rawTeam
+ * @returns {string|number|undefined}
+ */
+function resolveTeamId(rawTeam) {
+  return (
+    rawTeam.teamAbbrev?.default ||
+    rawTeam.teamId?.id ||
+    rawTeam.teamId ||
+    rawTeam.id ||
+    rawTeam.team?.id
+  );
+}
+
+/**
+ * Map a single raw NHL standings row into a StandingsTeamContract.
+ * Returns null for rows with no resolvable id (caller filters these out).
+ * @param {any} rawTeam
+ * @returns {StandingsTeamContract|null}
+ */
+function mapStandingsTeam(rawTeam) {
+  const teamId = resolveTeamId(rawTeam);
+  if (!teamId) {
+    console.warn(
+      "Skipping standings team with missing ID. Keys available:",
+      Object.keys(rawTeam),
+    );
+    return null;
+  }
+
+  const teamLogo = rawTeam.teamLogo ?? "";
+  const name = rawTeam.teamCommonName?.default ?? "";
+  const conferenceName = rawTeam.conferenceName ?? "";
+  const divisionName = rawTeam.divisionName ?? "";
+  const wins = rawTeam.wins ?? 0;
+  const losses = rawTeam.losses ?? 0;
+  const otLosses = rawTeam.otLosses ?? 0;
+  const points = rawTeam.points ?? 0;
+  const pointPctg = rawTeam.pointPctg ?? 0;
+  const leagueSequence = rawTeam.leagueSequence ?? 0;
+  const conferenceSequence = rawTeam.conferenceSequence ?? 0;
+  const divisionSequence = rawTeam.divisionSequence ?? 0;
+  const wildcardSequence = rawTeam.wildcardSequence ?? 0;
+  const clinchingIndicator =
+    rawTeam.clinchingIndicator || rawTeam.clinchIndicator || "";
+  const leagueL10Sequence = rawTeam.leagueL10Sequence ?? 0;
+
+  return /** @type {StandingsTeamContract} */ ({
+    teamId,
+    teamLogo,
+    name,
+    conferenceName,
+    divisionName,
+    wins,
+    losses,
+    otLosses,
+    points,
+    pointPctg,
+    leagueSequence,
+    conferenceSequence,
+    divisionSequence,
+    wildcardSequence,
+    clinchingIndicator,
+    leagueL10Sequence,
+  });
+}
+
+module.exports = { mapStandingsTeam, resolveTeamId };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,13 +95,13 @@ The frontend data layer lives under `react/src/Data/`.
 Use this structure when deciding where code belongs:
 
 - `Models/`: class-like data shapes used by the UI, such as `ScheduledGame`, `Team`, `StandingsTeam`, and `PlayerStatLeader`.
-- `Helpers/`: conversion logic from raw NHL API responses into app models.
+- `Helpers/`: conversion logic that wraps normalized backend contracts into app model classes (and layers on app-only logic such as draft-lottery odds). For the most-used NHL data, raw-field extraction now happens in the backend mappers (see [Backend Response Contracts](#backend-response-contracts)), so these helpers no longer parse raw NHL shapes.
 - `Context/`: React providers and hooks for shared state.
 - `Hooks/`: reusable custom hooks that compose services, helpers, and constants. For example, `useStatLeaders.ts` loads and tracks stat leader data using `STAT_CONFIG` and `PlayerStatLeaderConverter`.
 - `Constants/`: static configuration such as stat leader category mappings.
 - `LocalData/`: local static NHL team metadata and mock-shaped page data.
 
-The app often receives large, inconsistent NHL API objects. Helper files should convert those raw objects into stable app-specific models before the data reaches display components.
+The app often receives large, inconsistent NHL API objects. For the most-used NHL data (schedule games, standings teams, roster players, skater/goalie summaries, stat leaders) the backend now normalizes these into stable contracts before they reach the frontend; helper files wrap those contracts into model classes. When adding new NHL data, prefer normalizing at the backend boundary (a mapper) over re-parsing raw shapes in the browser.
 
 ### Page Responsibilities
 
@@ -135,29 +135,29 @@ Routes are grouped by NHL domain:
 - `api/routes/standings.js`
   - `GET /standings`
   - Fetches current standings from `https://api-web.nhle.com/v1/standings/now`
-  - Normalizes `clinchingIndicator`
+  - Normalizes each team into a `StandingsTeamContract` via `standingsMapper` (see [Backend Response Contracts](#backend-response-contracts))
 
 - `api/routes/schedule.js`
   - `GET /schedule/`
-  - Fetches a season-to-near-future schedule by calling weekly NHL schedule endpoints
+  - Fetches a season-to-near-future schedule by calling weekly NHL schedule endpoints, then returns `{ games }` where each game is a `ScheduleGameContract`
   - `GET /schedule/landing/:gameID`
-  - Fetches game landing data
+  - Fetches game landing data (raw passthrough)
   - `GET /schedule/:gameID`
-  - Fetches game boxscore data
+  - Fetches game boxscore data (raw passthrough)
 
 - `api/routes/team.js`
-  - `GET /team/roster/:triCode`
-  - `GET /team/schedule/:triCode`
-  - `GET /team/stats`
-  - `GET /team/:teamId?`
+  - `GET /team/roster/:triCode` — returns a normalized `RosterContract` (`{ players }`)
+  - `GET /team/schedule/:triCode` — returns `{ games }` of `ScheduleGameContract`, sorted by date
+  - `GET /team/stats` — raw team summary stats (not yet normalized)
+  - `GET /team/:teamId?` — raw team summary stats (not yet normalized)
   - Uses NHL team stats and club schedule endpoints
 
 - `api/routes/player.js`
-  - `GET /player/skater/statLeaders/:statIndicator`
-  - `GET /player/goalie/statLeaders/:statIndicator`
-  - `GET /player/skater/summary`
-  - `GET /player/skater/corsi`
-  - `GET /player/goalie/summary`
+  - `GET /player/skater/statLeaders/:statIndicator` — flat array of `StatLeaderContract`
+  - `GET /player/goalie/statLeaders/:statIndicator` — flat array of `StatLeaderContract`
+  - `GET /player/skater/summary` — array of `SkaterSummaryContract`
+  - `GET /player/skater/corsi` — raw passthrough (frontend merges into skater stats by `playerId`)
+  - `GET /player/goalie/summary` — array of `GoalieSummaryContract`
   - Uses NHL skater and goalie stats endpoints
 
 - `api/routes/health.js`
@@ -185,6 +185,23 @@ Routes are grouped by NHL domain:
 - `axiosNhlGoalie`: `https://api.nhle.com/stats/rest/en/goalie`
 
 Prefer these clients over creating new Axios instances inside route handlers.
+
+### Backend Response Contracts
+
+`api/services/mappers/` holds the normalization layer (an anti-corruption layer) that translates messy, inconsistent NHL API shapes into stable, documented contracts **once**, at the backend boundary. The frontend consumes these contracts, not raw NHL JSON, so NHL field renames are fixed in one mapper instead of across pages and helpers.
+
+Mapper modules, each documenting its shape(s) with a JSDoc `@typedef`:
+
+- `scheduleMapper.js` — `mapGame(rawGame, { date, dayAbbrev })` → `ScheduleGameContract`; `mapBroadcasts` → `GameBroadcastContract[]`. One mapper serves both schedule sources (the weekly endpoint supplies the date on the week; the club-schedule endpoint supplies it per game).
+- `standingsMapper.js` — `mapStandingsTeam(rawTeam)` → `StandingsTeamContract` (or `null` for rows with no resolvable id). Owns the `teamId` fallback chain and `clinchingIndicator`/`clinchIndicator` spelling normalization.
+- `rosterMapper.js` — `mapRoster(rawRoster)` → `RosterContract` (`{ players }`), flattening forwards/defensemen/goalies and keeping the raw position code.
+- `playerMapper.js` — `mapSkaterSummary`, `mapGoalieSummary`, and `mapStatLeaders(raw, category)`.
+
+Conventions for this layer:
+
+- **Mappers are pure functions** with defensive fallbacks for missing or renamed NHL fields (e.g. `venue?.default ?? ""`, guarded `.default` unwraps, `faceoffWinPct > 0 ? value : null`).
+- **Map after `GetOrFetch`, not inside it.** Cached entries store the **raw** NHL response, and the route maps on the way out. This means a mapper change never requires clearing the cache, and old cache entries stay compatible.
+- **Shape translation only.** App/derived/display logic stays on the frontend (e.g. draft-lottery odds in `LeagueStandingsHelper.ts`, TOI string formatting, `pointsPctg` rounding). Corsi (SAT%) is a separate endpoint merged on the frontend by `playerId` and is intentionally not part of the skater contract.
 
 ### Backend Caching
 
@@ -283,7 +300,7 @@ Useful domain terms:
 - `gameType=3`: playoffs.
 - `gameState`: NHL game state. The UI treats `FUT` and `PRE` as future/pre-game states. Completed games include states such as `OFF` and `FINAL`.
 - `cayenneExp`: NHL stats API query expression. Backend code URL-encodes these expressions before sending them to NHL stats endpoints.
-- `clinchingIndicator` / `clinchIndicator`: NHL standings APIs may use either spelling, so backend/frontend code normalizes this.
+- `clinchingIndicator` / `clinchIndicator`: NHL standings APIs may use either spelling. The backend `standingsMapper` normalizes this to `clinchingIndicator` so the frontend never has to.
 
 Draft lottery odds are currently calculated locally in `LeagueStandingsHelper.ts` based on league rank.
 
@@ -315,7 +332,8 @@ Draft lottery odds are currently calculated locally in `LeagueStandingsHelper.ts
 - Use `GetOrFetch` for data that is expensive, reused, or unlikely to need second-by-second freshness.
 - Choose cache keys that include every input affecting the response, such as team ID, tri-code, stat name, and season.
 - Pass errors to `next(error)` so the shared JSON error handler responds consistently.
-- Keep route handlers thin: validate/collect request inputs, call NHL APIs or helpers, normalize response shape, and return JSON.
+- Keep route handlers thin: validate/collect request inputs, fetch (via `GetOrFetch` where appropriate), then map the raw response through a mapper in `api/services/mappers/` before returning JSON. Put all NHL-field knowledge in the mapper, not the handler.
+- When normalizing cached data, map **after** `GetOrFetch` so the cache stores the raw response (see [Backend Response Contracts](#backend-response-contracts)).
 
 ### AI And Automation
 
@@ -349,5 +367,6 @@ The backend allows CORS from:
 
 ## Current Maintenance Notes
 
-- `TeamPage.tsx` has a lot of data transformation logic inline. If team page behavior grows, consider moving those transforms into helper files near `react/src/Data/Helpers/`.
+- `TeamPage.tsx` still holds some display-shaping logic inline (grouping roster players by position, formatting TOI, building stat rows), but the raw NHL parsing it used to duplicate now lives in the backend mappers. If team page behavior grows, consider moving the remaining display transforms into helper files near `react/src/Data/Helpers/`.
+- Team summary stats (`/team/stats`, `/team/:teamId?`) and skater corsi (`/player/skater/corsi`) are not yet normalized into contracts. If they grow more consumers, add mappers for them under `api/services/mappers/`.
 - The root `README.md` and existing architecture doc were empty at the time this document was written, so this file is the main architecture reference.

--- a/docs/phase-2-backlog.md
+++ b/docs/phase-2-backlog.md
@@ -28,7 +28,7 @@ Things to implement:
 
 ## 2.2 Normalize API response contracts
 
-- [ ] **Owner:** Either | **Depends on:** 2.1
+- [x] **Owner:** Either | **Depends on:** 2.1 | **Done:** 2026-05-31 (see [phase-2-progress.md](./phase-2-progress.md#22--normalize-api-response-contracts))
 
 Create stable backend response shapes for schedule, standings, teams, rosters, and player stats so frontend helpers do less defensive guessing against raw NHL API objects.
 

--- a/docs/phase-2-progress.md
+++ b/docs/phase-2-progress.md
@@ -39,15 +39,29 @@ Status legend: ☐ not started · ◐ in progress · ☑ done
 
 ---
 
-## ☐ 2.2 — Normalize API response contracts
+## ☑ 2.2 — Normalize API response contracts
+
+**Completed:** 2026-05-31
 
 ### What I have done
 
-_TODO_
+- Added a backend normalization layer (anti-corruption layer) in `api/services/mappers/`: `scheduleMapper.js`, `standingsMapper.js`, `rosterMapper.js`, and `playerMapper.js`. Each shape is documented with a JSDoc `@typedef`.
+- Normalized six shapes: `ScheduleGameContract` (+ `GameBroadcastContract`), `StandingsTeamContract`, `RosterPlayerContract`/`RosterContract`, `SkaterSummaryContract`, `GoalieSummaryContract`, and `StatLeaderContract`.
+- `scheduleMapper.mapGame(rawGame, { date, dayAbbrev })` serves both schedule sources (weekly `/schedule/` and club `/team/schedule/:triCode`), which supply the date differently. Playoff round/series logic and broadcast mapping that were duplicated in `ScheduleHelper.ts` and `TeamPage.tsx` now live here once.
+- Wired the routes to map **after** `GetOrFetch` so the cache keeps storing raw NHL data: `standings.js`, `schedule.js`, `team.js` (roster + schedule), and `player.js` (skater/goalie summary + skater/goalie stat leaders).
+- Updated frontend callers and deleted the duplicated transforms: `ScheduleHelper.ts` (now wraps contracts), `ScheduleContext.tsx`, `LeagueStandingsHelper.ts`, `PlayerStatLeaderConverter.ts`, `useStatLeaders.ts`, and `TeamPage.tsx` (removed `transformSchedule`, `convertBroadcasts`, `getDayOfWeek`; simplified `transformRoster`/`transformPlayerStats`).
+- Added defensive fallbacks throughout (guarded `.default` unwraps, `venue?.default ?? ""`, `faceoffWinPct > 0 ? value : null`). The guarded `.default` unwrap in `mapStatLeaders` fixed a latent crash where a missing player/team name would throw and silently empty a stat category.
+- Documented the layer in `docs/architecture.md` (new "Backend Response Contracts" section, plus route/helper/convention updates).
+- Verified: all backend route modules `require()` cleanly and `tsc --noEmit` passes with no errors.
 
 ### What I have learned
 
-_TODO_
+- **Push the anti-corruption layer to the boundary.** Raw NHL JSON was leaking all the way into React, so the same field-extraction lived in multiple places and drifted. Normalizing once at the backend boundary means an NHL field rename is a one-mapper fix.
+- **Separate shape translation from app logic.** Only raw-field extraction moved to the backend. App/derived/display logic (draft-lottery odds, TOI formatting, `pointsPctg` rounding) stayed on the frontend — the mapper should not own those.
+- **Map after `GetOrFetch`, not inside it.** Caching raw and mapping on the way out means mapper changes never require a cache clear and old cache entries stay compatible. Mapping is cheap; correctness/flexibility wins.
+- **Watch shape changes that ripple into logic.** Emitting `homeScore: null` (instead of the raw `undefined`) broke a `=== undefined` check in `ScheduleContext.doesGameNeedToUpdate`; fixed by comparing with `== null`.
+- **Field-name bugs are silent.** `teams.home.team.abbrev` vs `homeTeam.abbrev`, `gameId` vs `id`, `ticketLink` vs `ticketsLink` all return blank instead of throwing — the existing frontend helpers are the source of truth for verifying these.
+- **Flag unverified assumptions.** The goalie summary stat field names (`savePct`, etc.) weren't exercised by the old frontend, so they're best-guesses left with a `NOTE` and `?? null` guards — worth confirming against a live response.
 
 ---
 

--- a/react/src/Data/Context/ScheduleContext.tsx
+++ b/react/src/Data/Context/ScheduleContext.tsx
@@ -8,7 +8,7 @@ import React, {
 } from "react";
 import { ScheduledGame } from "../Models/ScheduledGame";
 import { GetGameDetails, GetScheduledGames } from "../../Services/ApiHandler";
-import ConvertWeekToGames from "../Helpers/ScheduleHelper";
+import ConvertContractsToGames from "../Helpers/ScheduleHelper";
 
 const ListOfGamesContext = createContext<any>(null);
 
@@ -20,14 +20,7 @@ const ListOfGamesProvider = ({ children }: { children: ReactNode }) => {
   async function fetchGames() {
     try {
       const response = await GetScheduledGames();
-      const week = response.gameWeek;
-      const localScheduledGames: ScheduledGame[] = [];
-      for (let i = 0; i < week.length; i++) {
-        if (week[i].numberOfGames > 0) {
-          localScheduledGames.push(...ConvertWeekToGames(week[i]));
-        }
-      }
-      setListOfGamesData(localScheduledGames);
+      setListOfGamesData(ConvertContractsToGames(response.games));
     } catch (error) {
       console.error("Error fetching games: ", error);
     } finally {
@@ -89,7 +82,7 @@ const ListOfGamesProvider = ({ children }: { children: ReactNode }) => {
     const gameDate = parseLocalDate(game.date);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    return gameDate < today && game.homeScore === undefined && game.awayScore === undefined;
+    return gameDate < today && game.homeScore == null && game.awayScore == null;
   }
 
   function parseLocalDate(dateStr: string | Date): Date {

--- a/react/src/Data/Helpers/LeagueStandingsHelper.ts
+++ b/react/src/Data/Helpers/LeagueStandingsHelper.ts
@@ -1,25 +1,18 @@
 import { StandingsTeam } from "../Models/StandingsTeam";
 
+/**
+ * The backend (api/services/mappers/standingsMapper.js) now returns each team in
+ * the StandingsTeamContract shape (id resolved, clinch indicator normalized, raw
+ * pointPctg). This helper only layers on app/display logic: pointsPctg rounding
+ * and the locally-computed draft-lottery odds + trend.
+ */
 export function CreateLeagueStandingsArray(initialStandings: any[]) {
   let leageuStandingsArray: StandingsTeam[] = [];
   for (let i = 0; i < initialStandings.length; i++) {
     const responseTeam = initialStandings[i];
-    const teamId =
-      responseTeam.teamAbbrev?.default ||
-      responseTeam.teamId?.id ||
-      responseTeam.teamId ||
-      responseTeam.id ||
-      responseTeam.team?.id;
-    if (!teamId) {
-      console.warn(
-        "Skipping team with missing ID. Keys available:",
-        Object.keys(responseTeam),
-        responseTeam,
-      );
-      continue;
-    }
+    const teamId = responseTeam.teamId;
     const teamLogo = responseTeam.teamLogo;
-    const name = responseTeam.teamCommonName.default;
+    const name = responseTeam.name;
     const conferenceName = responseTeam.conferenceName;
     const divisionName = responseTeam.divisionName;
     const wins = responseTeam.wins;
@@ -31,8 +24,7 @@ export function CreateLeagueStandingsArray(initialStandings: any[]) {
     const conferenceStanding = responseTeam.conferenceSequence;
     const divisionStanding = responseTeam.divisionSequence;
     const wildCardRank = responseTeam.wildcardSequence;
-    const clinchingIndicator =
-      responseTeam.clinchingIndicator || responseTeam.clinchIndicator || "";
+    const clinchingIndicator = responseTeam.clinchingIndicator;
 
     const teamLastTenLeagueRank: number = responseTeam.leagueL10Sequence;
     const teamDraftLotteryOdds: number = DraftLotteryOddsHelper(leagueStanding);

--- a/react/src/Data/Helpers/PlayerStatLeaderConverter.ts
+++ b/react/src/Data/Helpers/PlayerStatLeaderConverter.ts
@@ -1,51 +1,30 @@
 import { PlayerStatLeader } from "../Models/PlayerStatLeader";
 
-export default function PlayerStatLeaderConverter(playerLeaderResponseData:any, leadBy:string){
-    let localPlayerResponseData:any[] = [];
-    switch(leadBy){
-        case "goals":
-            localPlayerResponseData = playerLeaderResponseData.goals;
-            break;
-        case "assists":
-            localPlayerResponseData = playerLeaderResponseData.assists;
-            break;
-        case "points":
-            localPlayerResponseData = playerLeaderResponseData.points;
-            break;
-        case "faceoffLeaders":
-            localPlayerResponseData = playerLeaderResponseData.faceoffLeaders;
-            break;
-        case "wins":
-            localPlayerResponseData = playerLeaderResponseData.wins;
-            break;
-        case "savePctg":
-            localPlayerResponseData = playerLeaderResponseData.savePctg;
-            break;
-        case "goalsAgainstAverage":
-            localPlayerResponseData = playerLeaderResponseData.goalsAgainstAverage;
-            break;
-        case "shutouts":
-            localPlayerResponseData = playerLeaderResponseData.shutouts;
-            break;
-        default:
-            break;
-    }
+/**
+ * The backend (api/services/mappers/playerMapper.js -> mapStatLeaders) now returns
+ * a flat array of StatLeaderContract for the requested category, with the fragile
+ * `.default` unwrapping already done defensively server-side. This converter just
+ * wraps each contract in the PlayerStatLeader model the UI expects.
+ */
+export default function PlayerStatLeaderConverter(leaders: any[]) {
     let playerStatLeaderArray: PlayerStatLeader[] = [];
-    if (!Array.isArray(localPlayerResponseData)) return playerStatLeaderArray;
+    if (!Array.isArray(leaders)) return playerStatLeaderArray;
 
-    for (let i = 0; i < localPlayerResponseData.length; i++) {
-        const id: number = localPlayerResponseData[i].id;
-        const firstName: string = localPlayerResponseData[i].firstName.default;
-        const lastName: string = localPlayerResponseData[i].lastName.default;
-        const sweaterNumber = localPlayerResponseData[i].sweaterNumber;
-        const playerImage = localPlayerResponseData[i].headshot;
-        const teamAbbrev = localPlayerResponseData[i].teamAbbrev;
-        const teamName = localPlayerResponseData[i].teamName.default;
-        const teamLogo = localPlayerResponseData[i].teamLogo;
-        const position = localPlayerResponseData[i].position;
-        const value = localPlayerResponseData[i].value;
-
-        const playerStatLeader: PlayerStatLeader = new PlayerStatLeader(id, firstName, lastName, sweaterNumber, playerImage, teamAbbrev, teamName, teamLogo, position, true, value);
+    for (let i = 0; i < leaders.length; i++) {
+        const leader = leaders[i];
+        const playerStatLeader: PlayerStatLeader = new PlayerStatLeader(
+            leader.id,
+            leader.firstName,
+            leader.lastName,
+            leader.sweaterNumber,
+            leader.headshot,
+            leader.teamAbbrev,
+            leader.teamName,
+            leader.teamLogo,
+            leader.position,
+            true,
+            leader.value,
+        );
         playerStatLeaderArray.push(playerStatLeader);
     }
     return playerStatLeaderArray;

--- a/react/src/Data/Helpers/ScheduleHelper.ts
+++ b/react/src/Data/Helpers/ScheduleHelper.ts
@@ -1,95 +1,43 @@
 import { GameBroadcast } from "../Models/GameBroadcast";
 import { ScheduledGame } from "../Models/ScheduledGame";
 
-export default function ConvertWeekToGames(week: any) {
-  const games = week.games;
-  const date = week.date;
-  const dayOfWeek = week.dayAbbrev;
+/**
+ * The backend (api/services/mappers/scheduleMapper.js) now returns games already
+ * normalized into the ScheduleGameContract shape, so the frontend only wraps each
+ * contract in the ScheduledGame / GameBroadcast model classes the UI expects.
+ * All NHL-field extraction + playoff logic now lives in the backend mapper.
+ */
 
-  let localListOfGames: ScheduledGame[] = [];
+function ConvertContractToGame(g: any): ScheduledGame {
+  const broadcasts: GameBroadcast[] = (g.broadcasts ?? []).map(
+    (b: any) => new GameBroadcast(b.id, b.network, b.market, b.countryCode),
+  );
 
-  for (let i = 0; i < games.length; i++) {
-    const gameState = games[i].gameState;
-
-    const gameId = games[i].id;
-    const gameTime = games[i].startTimeUTC;
-    const venue = games[i].venue.default;
-    const homeTeam = games[i].homeTeam.abbrev;
-    const homeLogo = games[i].homeTeam.logo;
-    const homeScore = games[i].homeTeam.score;
-    const awayTeam = games[i].awayTeam.abbrev;
-    const awayLogo = games[i].awayTeam.logo;
-    const awayScore = games[i].awayTeam.score;
-    const broadcasts = ConvertToListOfBroadcasts(games[i].tvBroadcasts);
-    let ticketLink = "";
-    if (gameState === "FUT") {
-      ticketLink = games[i].ticketsLink;
-    }
-    const gameCenter = games[i].gameCenterLink;
-    const isPlayoff = games[i].gameType === 3;
-    let topSeedTeamAbbrev;
-    let bottomSeedTeamAbbrev;
-    const playoffRound: number | null = (() => {
-      if (!isPlayoff) return null;
-      if (games[i].seriesStatus?.round != null){
-        topSeedTeamAbbrev = games[i].seriesStatus?.topSeedTeamAbbrev ?? null;
-        bottomSeedTeamAbbrev = games[i].seriesStatus?.bottomSeedTeamAbbrev ?? null;
-        return games[i].seriesStatus.round;
-      }
-      const idStr = String(games[i].id ?? "");
-      return idStr.length === 10 ? parseInt(idStr.slice(6, 8)) || null : null;
-    })();
-    const periodType: string | null =
-      games[i].periodDescriptor?.periodType ?? null;
-    const seriesWins: string | null = (() => {
-      if (!isPlayoff) return null;
-      const top = games[i].seriesStatus?.topSeedWins;
-      const bot = games[i].seriesStatus?.bottomSeedWins;
-      return top != null && bot != null ? `${top}-${bot}` : null;
-    })();
-
-    const game: ScheduledGame = new ScheduledGame(
-      gameId,
-      date,
-      gameTime,
-      dayOfWeek,
-      venue,
-      homeTeam,
-      homeLogo,
-      homeScore,
-      awayTeam,
-      awayLogo,
-      awayScore,
-      broadcasts,
-      ticketLink,
-      gameCenter,
-      isPlayoff,
-      playoffRound,
-      periodType,
-      seriesWins,
-      topSeedTeamAbbrev,
-      bottomSeedTeamAbbrev,
-      gameState
-    );
-    localListOfGames.push(game);
-  }
-  return localListOfGames;
+  return new ScheduledGame(
+    g.gameId,
+    g.date,
+    g.gameTime,
+    g.dayOfWeek,
+    g.venue,
+    g.homeTeam,
+    g.homeLogo,
+    g.homeScore,
+    g.awayTeam,
+    g.awayLogo,
+    g.awayScore,
+    broadcasts,
+    g.ticketLink,
+    g.gameCenter,
+    g.isPlayoff,
+    g.playoffRound,
+    g.periodType,
+    g.seriesWins,
+    g.topSeedTeamAbbrev,
+    g.bottomSeedTeamAbbrev,
+    g.gameState,
+  );
 }
-function ConvertToListOfBroadcasts(broadcasts: any) {
-  let localListOfBroadcasts: GameBroadcast[] = [];
-  for (let i = 0; i < broadcasts.length; i++) {
-    const id = broadcasts[i].id;
-    const broadcastName = broadcasts[i].network;
-    const market = broadcasts[i].market;
-    const broadcastCountry = broadcasts[i].countryCode;
 
-    const broadcast: GameBroadcast = new GameBroadcast(
-      id,
-      broadcastName,
-      market,
-      broadcastCountry,
-    );
-    localListOfBroadcasts.push(broadcast);
-  }
-  return localListOfBroadcasts;
+export default function ConvertContractsToGames(games: any[]): ScheduledGame[] {
+  return (games ?? []).map(ConvertContractToGame);
 }

--- a/react/src/Data/Hooks/useStatLeaders.ts
+++ b/react/src/Data/Hooks/useStatLeaders.ts
@@ -21,7 +21,7 @@ export function useStatLeaders(type: StatLeaderType) {
   async function fetchStat({ displayKey, apiKey }: StatEntry) {
     try {
       const data = await fetcher(apiKey);
-      const statLeaders: PlayerStatLeader[] = PlayerStatLeaderConverter(data, apiKey);
+      const statLeaders: PlayerStatLeader[] = PlayerStatLeaderConverter(data);
       if (statLeaders.length === 0) return;
       const topLeader = new TopStatLeader(displayKey, statLeaders[0], statLeaders);
       setLeaders(prev => ({ ...prev, [displayKey]: topLeader }));

--- a/react/src/Pages/TeamPage.tsx
+++ b/react/src/Pages/TeamPage.tsx
@@ -17,8 +17,8 @@ import {
   RosterPlayer,
   PlayerStatLine,
 } from "../Data/LocalData/TeamPageMockData";
-import { GameBroadcast } from "../Data/Models/GameBroadcast";
 import { ScheduledGame } from "../Data/Models/ScheduledGame";
+import ConvertContractsToGames from "../Data/Helpers/ScheduleHelper";
 import {
   GetTeamStatsById,
   GetTeamRoster,
@@ -56,24 +56,19 @@ function formatToi(seconds: number): string {
 }
 
 function transformRoster(
-  rosterData: any,
+  players: any[],
   toiMap: Map<number, number>,
 ): Record<Position, RosterPlayer[]> {
   const result = buildEmptyRoster();
-  const all = [
-    ...(rosterData.forwards ?? []),
-    ...(rosterData.defensemen ?? []),
-    ...(rosterData.goalies ?? []),
-  ];
-  for (const p of all) {
-    const pos = POS_MAP[p.positionCode] as Position;
+  for (const p of players ?? []) {
+    const pos = POS_MAP[p.position] as Position;
     if (!pos) continue;
     const toi = toiMap.get(p.id);
     const stat = toi != null ? formatToi(toi) : "";
     result[pos].push({
       id: p.id,
-      name: `${p.firstName?.default ?? ""} ${p.lastName?.default ?? ""}`.trim(),
-      number: p.sweaterNumber ?? 0,
+      name: p.name,
+      number: p.number ?? 0,
       stat,
       headshot: p.headshot ?? "",
     });
@@ -98,83 +93,8 @@ function transformRoster(
   return result;
 }
 
-function convertBroadcasts(broadcasts: any[] = []): GameBroadcast[] {
-  return broadcasts.map(
-    (broadcast) =>
-      new GameBroadcast(
-        broadcast.id,
-        broadcast.network,
-        broadcast.market,
-        broadcast.countryCode,
-      ),
-  );
-}
-
-function getDayOfWeek(gameDate: string): string {
-  return new Date(`${gameDate}T12:00:00`).toLocaleDateString("en-US", {
-    weekday: "short",
-  });
-}
-
-function transformSchedule(
-  scheduleData: any,
-): ScheduledGame[] {
-  const games: any[] = scheduleData.games ?? [];
-  const sorted = [...games].sort(
-    (a, b) =>
-      new Date(a.gameDate + "T12:00:00").getTime() -
-      new Date(b.gameDate + "T12:00:00").getTime(),
-  );
-
-  return sorted.map((g) => {
-    const isPlayoff = g.gameType === 3;
-    let topSeedTeamAbbrev: string | null = null;
-    let bottomSeedTeamAbbrev: string | null = null;
-    const playoffRound: number | null = (() => {
-        if (g.gameType !== 3) return null;
-        if (g.seriesStatus?.round != null) {
-          topSeedTeamAbbrev = g.seriesStatus?.topSeedTeamAbbrev ?? null;
-          bottomSeedTeamAbbrev = g.seriesStatus?.bottomSeedTeamAbbrev ?? null;
-          return g.seriesStatus.round;
-        }
-        const idStr = String(g.id ?? "");
-        return idStr.length === 10 ? parseInt(idStr.slice(6, 8)) || null : null;
-      })();
-    const seriesWins: string | null = (() => {
-        if (g.gameType !== 3) return null;
-        const top = g.seriesStatus?.topSeedWins;
-        const bot = g.seriesStatus?.bottomSeedWins;
-        return top != null && bot != null ? `${top}-${bot}` : null;
-      })();
-
-    return new ScheduledGame(
-      g.id,
-      g.gameDate,
-      g.startTimeUTC,
-      getDayOfWeek(g.gameDate),
-      g.venue?.default ?? "",
-      g.homeTeam?.abbrev ?? "",
-      g.homeTeam?.logo ?? "",
-      g.homeTeam?.score,
-      g.awayTeam?.abbrev ?? "",
-      g.awayTeam?.logo ?? "",
-      g.awayTeam?.score,
-      convertBroadcasts(g.tvBroadcasts),
-      g.gameState === "FUT" ? g.ticketsLink ?? "" : "",
-      g.gameCenterLink ?? "",
-      isPlayoff,
-      playoffRound,
-      g.periodDescriptor?.periodType ?? null,
-      seriesWins,
-      topSeedTeamAbbrev,
-      bottomSeedTeamAbbrev,
-      g.gameState,
-    );
-  });
-}
-
 function transformPlayerStats(
-  summaryData: any,
+  summary: any[],
   corsiData: any,
 ): PlayerStatLine[] {
   const corsiMap = new Map<number, number>();
@@ -182,18 +102,19 @@ function transformPlayerStats(
     if (p.playerId != null && p.satPercentage != null)
       corsiMap.set(p.playerId, p.satPercentage);
   }
-  return (summaryData?.data ?? []).map(
+  return (summary ?? []).map(
     (p: any): PlayerStatLine => ({
       playerId: p.playerId,
-      name: p.skaterFullName ?? "",
-      position: p.positionCode ?? "",
+      name: p.name ?? "",
+      position: p.position ?? "",
       gamesPlayed: p.gamesPlayed ?? 0,
       goals: p.goals ?? 0,
       assists: p.assists ?? 0,
       points: p.points ?? 0,
       plusMinus: p.plusMinus ?? 0,
       penaltyMinutes: p.penaltyMinutes ?? 0,
-      faceoffWinPct: p.faceoffWinPct > 0 ? p.faceoffWinPct : null,
+      // Backend already maps "no faceoffs" (0) to null; pass it through.
+      faceoffWinPct: p.faceoffWinPct ?? null,
       corsiPct: corsiMap.get(p.playerId) ?? null,
     }),
   );
@@ -316,27 +237,22 @@ export default function TeamPage() {
         });
 
         const toiMap = new Map<number, number>();
-        for (const p of summaryRes?.data ?? []) {
-          if (p.playerId != null && p.timeOnIcePerGame != null)
-            toiMap.set(p.playerId, p.timeOnIcePerGame);
+        for (const p of summaryRes ?? []) {
+          if (p.playerId != null && p.toiPerGame != null)
+            toiMap.set(p.playerId, p.toiPerGame);
         }
-        for (const g of goalieRes?.data ?? []) {
-          if (g.goalieId != null && g.timeOnIcePerGame != null)
-            toiMap.set(g.goalieId, g.timeOnIcePerGame);
+        for (const g of goalieRes ?? []) {
+          if (g.goalieId != null && g.toiPerGame != null)
+            toiMap.set(g.goalieId, g.toiPerGame);
         }
-        const allRosterPlayers = [
-          ...(rosterRes.forwards ?? []),
-          ...(rosterRes.defensemen ?? []),
-          ...(rosterRes.goalies ?? []),
-        ];
         const newHeadshotMap = new Map<number, string>();
-        for (const p of allRosterPlayers) {
+        for (const p of rosterRes.players ?? []) {
           if (p.id && p.headshot) newHeadshotMap.set(p.id, p.headshot);
         }
         setHeadshotMap(newHeadshotMap);
         setStats(transformTeamStats(raw));
-        setSchedule(transformSchedule(scheduleRes));
-        setRoster(transformRoster(rosterRes, toiMap));
+        setSchedule(ConvertContractsToGames(scheduleRes.games));
+        setRoster(transformRoster(rosterRes.players, toiMap));
         setPlayerStats(transformPlayerStats(summaryRes, corsiRes));
       } catch (err) {
         console.error("Error loading team data", err);

--- a/react/src/Services/AxiosInstance.ts
+++ b/react/src/Services/AxiosInstance.ts
@@ -10,6 +10,5 @@ if (!apiBaseUrl && import.meta.env.PROD) {
 
 export const axiosExpressHandler = axios.create({
   baseURL: apiBaseUrl,
-  headers: {'Access-Control-Allow-Headers ' : '*'},
   withCredentials: false
 });


### PR DESCRIPTION
  New backend normalization layer — api/services/mappers/
  - scheduleMapper.js — ScheduleGameContract (+ GameBroadcastContract). One mapGame(rawGame, { date, dayAbbrev }) serves both the weekly /schedule/ and club /team/schedule/:triCode sources, which supply the date differently.
  - standingsMapper.js — StandingsTeamContract. Owns the teamId fallback chain and clinchingIndicator/clinchIndicator spelling normalization.
  - rosterMapper.js — RosterContract ({ players }), flattening forwards/defensemen/goalies.
  - playerMapper.js — SkaterSummaryContract, GoalieSummaryContract, StatLeaderContract.
  - Each shape is documented with a JSDoc @typedef.
  
  Routes wired to map after GetOrFetch (cache keeps storing raw NHL data, so mapper changes never need a cache clear): standings.js, schedule.js, team.js (roster + schedule), player.js (skater/goalie summary + stat leaders).

  Frontend callers updated; duplicated transforms deleted
  - ScheduleHelper.ts now just wraps contracts in model classes (playoff/series/broadcast logic removed).
  - TeamPage.tsx lost transformSchedule, convertBroadcasts, getDayOfWeek; transformRoster/transformPlayerStats simplified to read contract fields.
  - LeagueStandingsHelper.ts, PlayerStatLeaderConverter.ts, ScheduleContext.tsx, useStatLeaders.ts updated to the new shapes.
  
  Notable fixes & decisions

  - Latent crash fixed: PlayerStatLeaderConverter did unguarded .default access; a missing player/team name would throw and silently empty a stat category. The backend mapStatLeaders now guards these.
  - Shape translation only: app/derived logic (draft-lottery odds, TOI formatting, pointsPctg rounding) stays on the frontend by design. Corsi (SAT%) remains a separate endpoint merged frontend-side by playerId.
  - Null vs undefined: the mapper emits homeScore: null for scoreless games; updated ScheduleContext.doesGameNeedToUpdate from === undefined to == null so past-game score updates still fire.