### PR TITLE
Fix stale lockfile breaking CI build; improve load-time performance

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 var createError = require('http-errors');
+var compression = require('compression');
 var cors = require('cors');
 var express = require('express');
 var path = require('path');
@@ -31,6 +32,7 @@ let corsOptions = {
 
 var app = express();
 
+app.use(compression());
 app.use(cors(corsOptions));
 app.use(logger('dev'));
 app.use(express.json());

--- a/api/package.json
+++ b/api/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "axios": "^1.16.1",
+    "compression": "^1.8.1",
     "cookie-parser": "~1.4.7",
     "cors": "^2.8.6",
     "debug": "~2.6.9",

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       axios:
         specifier: ^1.16.1
         version: 1.16.1(debug@2.6.9)
+      compression:
+        specifier: ^1.8.1
+        version: 1.8.1
       cookie-parser:
         specifier: ~1.4.7
         version: 1.4.7
@@ -85,6 +88,10 @@ packages:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -92,6 +99,14 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  compressible@2.0.18:
+    resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
+    engines: {node: '>= 0.6'}
+
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
+    engines: {node: '>= 0.8.0'}
 
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -319,6 +334,10 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -329,6 +348,10 @@ packages:
 
   on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   parseurl@1.3.3:
@@ -420,6 +443,9 @@ packages:
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -590,6 +616,8 @@ snapshots:
 
   bytes@3.0.0: {}
 
+  bytes@3.1.2: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -598,6 +626,22 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  compressible@2.0.18:
+    dependencies:
+      mime-db: 1.52.0
+
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   content-disposition@0.5.2: {}
 
@@ -825,6 +869,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@0.6.4: {}
+
   object-assign@4.1.1: {}
 
   on-finished@2.3.0:
@@ -832,6 +878,8 @@ snapshots:
       ee-first: 1.1.1
 
   on-headers@1.0.2: {}
+
+  on-headers@1.1.0: {}
 
   parseurl@1.3.3: {}
 
@@ -909,6 +957,8 @@ snapshots:
   retry-as-promised@7.1.1: {}
 
   safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 

--- a/react/pnpm-lock.yaml
+++ b/react/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       react-router-dom:
         specifier: ^6.30.3
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      web-vitals:
-        specifier: ^3.5.2
-        version: 3.5.2
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.7.0
@@ -1067,9 +1064,6 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
-  web-vitals@3.5.2:
-    resolution: {integrity: sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==}
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2027,8 +2021,6 @@ snapshots:
   warning@4.0.3:
     dependencies:
       loose-envify: 1.4.0
-
-  web-vitals@3.5.2: {}
 
   yallist@3.1.1: {}
 

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,16 +1,18 @@
-import LandingPage from './Pages/LandingPage';
+import { lazy, Suspense } from 'react';
 import { HashRouter, Routes, Route } from 'react-router-dom';
-import StandingsPage from './Pages/StandingsPage';
-import TeamPage from './Pages/TeamPage';
-import TeamList from './Pages/TeamList';
-import SchedulePage from './Pages/SchedulePage';
-import GameDetailPage from './Pages/GameDetailPage';
-import DiagnosticsPage from './Pages/DiagnosticsPage';
 import { SkaterStatLeaderProvider } from './Data/Context/SkaterStatLeadersContext';
 import { GoalieLeaderDataProvider } from './Data/Context/GoalieStatLeadersContext';
 import { ListOfGamesProvider } from './Data/Context/ScheduleContext';
 import { SeasonProvider } from './Data/Context/SeasonContext';
 import { StandingsDataProvider } from './Data/Context/StandingsContext';
+
+const LandingPage = lazy(() => import('./Pages/LandingPage'));
+const StandingsPage = lazy(() => import('./Pages/StandingsPage'));
+const TeamPage = lazy(() => import('./Pages/TeamPage'));
+const TeamList = lazy(() => import('./Pages/TeamList'));
+const SchedulePage = lazy(() => import('./Pages/SchedulePage'));
+const GameDetailPage = lazy(() => import('./Pages/GameDetailPage'));
+const DiagnosticsPage = lazy(() => import('./Pages/DiagnosticsPage'));
 
 /**
  * Route table plus the providers that depend on routing or the selected season.
@@ -27,15 +29,17 @@ export default function App() {
           <ListOfGamesProvider>
             <SkaterStatLeaderProvider>
               <GoalieLeaderDataProvider>
-                <Routes>
-                  <Route path="/" element={<LandingPage />} />
-                  <Route path="standings" element={<StandingsPage />} />
-                  <Route path="schedule" element={<SchedulePage />} />
-                  <Route path="teamList" element={<TeamList />} />
-                  <Route path="team/:teamId" element={<TeamPage />} />
-                  <Route path="game/:gameId" element={<GameDetailPage />} />
-                  <Route path="diagnostics" element={<DiagnosticsPage />} />
-                </Routes>
+                <Suspense fallback={null}>
+                  <Routes>
+                    <Route path="/" element={<LandingPage />} />
+                    <Route path="standings" element={<StandingsPage />} />
+                    <Route path="schedule" element={<SchedulePage />} />
+                    <Route path="teamList" element={<TeamList />} />
+                    <Route path="team/:teamId" element={<TeamPage />} />
+                    <Route path="game/:gameId" element={<GameDetailPage />} />
+                    <Route path="diagnostics" element={<DiagnosticsPage />} />
+                  </Routes>
+                </Suspense>
               </GoalieLeaderDataProvider>
             </SkaterStatLeaderProvider>
           </ListOfGamesProvider>

--- a/react/src/Data/Context/ScheduleContext.tsx
+++ b/react/src/Data/Context/ScheduleContext.tsx
@@ -76,17 +76,18 @@ function ListOfGamesProvider({ children }: { children: ReactNode }) {
       );
       if (gamesThatNeedToUpdate.length === 0) return;
 
-      const updatedGamesList: ScheduledGame[] = [...listOfGamesData];
-      for (const game of gamesThatNeedToUpdate) {
-        const updatedGame: ScheduledGame | undefined = await updateGame(game);
-        if (updatedGame) {
-          const index = updatedGamesList.findIndex(
-            (g: ScheduledGame) => g.gameId === updatedGame.gameId,
-          );
-          updatedGamesList[index] = updatedGame;
-        }
+      const updatedGames = await Promise.all(
+        gamesThatNeedToUpdate.map((game) => updateGame(game)),
+      );
+
+      const updatedMap = new Map<number, ScheduledGame>();
+      for (const game of updatedGames) {
+        if (game) updatedMap.set(game.gameId, game);
       }
-      setListOfGamesData(updatedGamesList);
+
+      setListOfGamesData((prev) =>
+        prev.map((g) => updatedMap.get(g.gameId) ?? g),
+      );
     }
   }, [listOfGamesData, loadingListOfGamesData]);
 


### PR DESCRIPTION
- Regenerate react/pnpm-lock.yaml after web-vitals removal (fixes CI ERR_PNPM_OUTDATED_LOCKFILE)
- Lazy-load all route pages with React.lazy/Suspense for route-level code splitting
- Parallelize stale game-detail fetches with Promise.all instead of sequential awaits
- Add gzip compression middleware to Express API to reduce response payload sizes

https://claude.ai/code/session_01AGneAarF51ti5uoLBpeqnF